### PR TITLE
Exception-handling, documentation, DRY extern-def macro improvements

### DIFF
--- a/Cvc5Test/MkTerms1.lean
+++ b/Cvc5Test/MkTerms1.lean
@@ -19,10 +19,10 @@ def mkTerms1 : IO Unit := do
   let intKind := Kind.CONST_INTEGER
 
   let (one, three, seven, eleven) := (
-    tm.mkInteger 1,
-    tm.mkInteger 3,
-    tm.mkInteger 7,
-    tm.mkInteger 11,
+    tm.mkInteger! 1,
+    tm.mkInteger! 3,
+    tm.mkInteger! 7,
+    tm.mkInteger! 11,
   )
   assertEq one.getKind intKind
   assertEq one.getSort.toString "Int"
@@ -34,22 +34,22 @@ def mkTerms1 : IO Unit := do
   assertEq eleven.getSort.toString "Int"
 
   let ite1 :=
-    tm.mkTerm Kind.ITE #[fls, three, seven]
+    tm.mkTerm! Kind.ITE #[fls, three, seven]
   assertEq ite1.getKind Kind.ITE
   assertEq ite1.getSort.toString "Int"
 
   let eq1 :=
-    tm.mkTerm Kind.EQUAL #[ite1, eleven]
+    tm.mkTerm! Kind.EQUAL #[ite1, eleven]
   assertEq eq1.getKind Kind.EQUAL
   assertEq eq1.getSort.toString "Bool"
 
   let eq1' :=
-    tm.mkTerm Kind.EQUAL #[ite1, eleven, one]
+    tm.mkTerm! Kind.EQUAL #[ite1, eleven, one]
   assertEq eq1'.getKind Kind.AND
   assertEq eq1'.getSort.toString "Bool"
 
   let ite2 :=
-    tm.mkTerm Kind.ITE #[tru, eq1, fls]
+    tm.mkTerm! Kind.ITE #[tru, eq1, fls]
   assertEq ite2.getKind Kind.ITE
   assertEq ite2.getSort.toString "Bool"
 

--- a/Cvc5Test/MkTerms1.lean
+++ b/Cvc5Test/MkTerms1.lean
@@ -19,10 +19,10 @@ def mkTerms1 : IO Unit := do
   let intKind := Kind.CONST_INTEGER
 
   let (one, three, seven, eleven) := (
-    tm.mkInteger! 1,
-    tm.mkInteger! 3,
-    tm.mkInteger! 7,
-    tm.mkInteger! 11,
+    tm.mkInteger 1,
+    tm.mkInteger 3,
+    tm.mkInteger 7,
+    tm.mkInteger 11,
   )
   assertEq one.getKind intKind
   assertEq one.getSort.toString "Int"

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -129,6 +129,7 @@ instance : ToString Result := ⟨Result.toString⟩
 end Result
 
 section ffi_except_constructors
+
 /-- Only used by FFI to inject values. -/
 @[export except_ok]
 private def mkExceptOk {α : Type} : α → Except Error α :=
@@ -153,6 +154,7 @@ private def mkExceptOkU8 : UInt8 → Except Error UInt8 :=
 @[export except_err]
 private def mkExceptErr {α : Type} : String → Except Error α :=
   .error ∘ Error.error
+
 end ffi_except_constructors
 
 end cvc5
@@ -496,10 +498,8 @@ extern! "termManager"
   /-- Create an integer-value term. -/
   private def mkIntegerFromString : TermManager → String → Except Error Term
   with
-    mkInteger (tm : TermManager) : Int → Except Error Term :=
-      tm.mkIntegerFromString ∘ toString
-    mkInteger? := (mkInteger · · |> Except.toOption)
-    mkInteger! := (mkInteger · · |> Error.unwrap!)
+    mkInteger (tm : TermManager) : Int → Term :=
+      Error.unwrap! ∘ tm.mkIntegerFromString ∘ toString
 
   /-- Create operator of Kind:
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -461,11 +461,17 @@ namespace Solver
 
 variable [Monad m]
 
+/-- Only used by FFI to wrap *success* results. -/
 @[export solver_val]
 private def val (a : α) : SolverT m α := pure a
 
+/-- Only used by FFI to wrap errors. -/
 @[export solver_err]
 private def err (e : Error) : SolverT m α := throw e
+
+/-- Only used by FFI to wrap cvc5 errors. -/
+@[export solver_errOfString]
+private def errorOfString (msg : String) : SolverT m α := throw (.error msg)
 
 extern! "solver"
   private def new : TermManager → Solver

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -108,21 +108,19 @@ end Error
 
 namespace Result
 
-extern! "result"
+/-- True if this result is from a satisfiable `checkSat` or `checkSatAssuming` query. -/
+extern_def isSat : Result → Bool
 
-  /-- True if this result is from a satisfiable `checkSat` or `checkSatAssuming` query. -/
-  def isSat : Result → Bool
+/-- True if this result is from a unsatisfiable `checkSat` or `checkSatAssuming` query. -/
+extern_def isUnsat : Result → Bool
 
-  /-- True if this result is from a unsatisfiable `checkSat` or `checkSatAssuming` query. -/
-  def isUnsat : Result → Bool
+/-- True if this result is from a `checkSat` or `checkSatAssuming` query and cvc5 was not able to
+determine (un)satisfiability.
+-/
+extern_def isUnknown : Result → Bool
 
-  /-- True if this result is from a `checkSat` or `checkSatAssuming` query and cvc5 was not able to
-  determine (un)satisfiability.
-  -/
-  def isUnknown : Result → Bool
-
-  /-- A string representation of this result. -/
-  protected def toString : Result → String
+/-- A string representation of this result. -/
+protected extern_def toString : Result → String
 
 instance : ToString Result := ⟨Result.toString⟩
 
@@ -161,53 +159,49 @@ end cvc5
 
 namespace cvc5.Sort
 
-extern! "sort"
-  def null : Unit → cvc5.Sort
+/-- The null sort. -/
+extern_def null : Unit → cvc5.Sort
 
 instance : Inhabited cvc5.Sort := ⟨null ()⟩
 
-extern! "sort"
-  /-- Comparison for structural equality. -/
-  protected def beq : cvc5.Sort → cvc5.Sort → Bool
+/-- Comparison for structural equality. -/
+protected extern_def beq : cvc5.Sort → cvc5.Sort → Bool
 
 instance : BEq cvc5.Sort := ⟨Sort.beq⟩
 
-extern! "sort"
-  /-- Hash function for cvc5 sorts. -/
-  protected def hash : cvc5.Sort → UInt64
+/-- Hash function for cvc5 sorts. -/
+protected extern_def hash : cvc5.Sort → UInt64
 
 instance : Hashable cvc5.Sort := ⟨Sort.hash⟩
 
-extern! "sort"
+/-- Get the kind of this sort. -/
+extern_def getKind : cvc5.Sort → SortKind
 
-  /-- Get the kind of this sort. -/
-  def getKind : cvc5.Sort → SortKind
+/-- Determine if this is the integer sort (SMT-LIB: `Int`). -/
+extern_def isInteger : cvc5.Sort → Bool
 
-  /-- Determine if this is the integer sort (SMT-LIB: `Int`). -/
-  def isInteger : cvc5.Sort → Bool
+/-- Determine if this is a function sort. -/
+protected extern_def isFunction : cvc5.Sort → Bool
 
-  /-- Determine if this is a function sort. -/
-  protected def isFunction : cvc5.Sort → Bool
+/-- A string representation of this sort. -/
+protected extern_def toString : cvc5.Sort → String
 
-  /-- A string representation of this sort. -/
-  protected def toString : cvc5.Sort → String
+/-- Get the symbol of this sort.
 
-  /-- Get the symbol of this sort.
+The symbol of this sort is the string that was provided when consrtucting it *via* one of
+`Solver.mkUninterpretedSort`, `Solver.mkUnresolvedSort`, or
+`Solver.mkUninterpretedSortConstructorSort`.
+-/
+extern_def!? getSymbol : cvc5.Sort → Except Error String
 
-  The symbol of this sort is the string that was provided when consrtucting it *via* one of
-  `Solver.mkUninterpretedSort`, `Solver.mkUnresolvedSort`, or
-  `Solver.mkUninterpretedSortConstructorSort`.
-  -/
-  def !? getSymbol : cvc5.Sort → Except Error String
+/-- The domain sorts of a function sort. -/
+extern_def!? getFunctionDomainSorts : cvc5.Sort → Except Error (Array cvc5.Sort)
 
-  /-- The domain sorts of a function sort. -/
-  def !? getFunctionDomainSorts : cvc5.Sort → Except Error (Array cvc5.Sort)
+/-- The codomain sort of a function sort. -/
+extern_def!? getFunctionCodomainSort : cvc5.Sort → Except Error cvc5.Sort
 
-  /-- The codomain sort of a function sort. -/
-  def !? getFunctionCodomainSort : cvc5.Sort → Except Error cvc5.Sort
-
-  /-- The bit-width of the bit-vector sort. -/
-  def !? getBitVectorSize : cvc5.Sort → Except Error UInt32
+/-- The bit-width of the bit-vector sort. -/
+extern_def!? getBitVectorSize : cvc5.Sort → Except Error UInt32
 
 instance : ToString cvc5.Sort := ⟨Sort.toString⟩
 instance : Repr cvc5.Sort := ⟨fun self _ => self.toString⟩
@@ -216,36 +210,33 @@ end cvc5.Sort
 
 namespace cvc5.Op
 
-extern! "op"
-  def null : Unit → Op
+/-- The null operator. -/
+extern_def null : Unit → Op
 
 instance : Inhabited Op := ⟨null ()⟩
 
-extern! "op"
-  /-- Syntactic equality operator. -/
-  protected def beq : Op → Op → Bool
+/-- Syntactic equality operator. -/
+protected extern_def beq : Op → Op → Bool
 
 instance : BEq Op := ⟨Op.beq⟩
 
-extern! "op"
+/-- Get the kind of this operator. -/
+extern_def getKind : Op → Kind
 
-  /-- Get the kind of this operator. -/
-  def getKind : Op → Kind
+/-- Determine if this operator is nullary. -/
+extern_def isNull : Op → Bool
 
-  /-- Determine if this operator is nullary. -/
-  def isNull : Op → Bool
+/-- Determine if this operator is indexed. -/
+extern_def isIndexed : Op → Bool
 
-  /-- Determine if this operator is indexed. -/
-  def isIndexed : Op → Bool
+/-- Get the number of indices of this operator. -/
+extern_def getNumIndices : Op → Nat
 
-  /-- Get the number of indices of this operator. -/
-  def getNumIndices : Op → Nat
+/-- Get the index at position `i` of an indexed operator. -/
+protected extern_def get : (op : Op) → Fin op.getNumIndices → Term
 
-  /-- Get the index at position `i` of an indexed operator. -/
-  protected def get : (op : Op) → Fin op.getNumIndices → Term
-
-  /-- Get the string representation of this operator. -/
-  protected def toString : Op → String
+/-- Get the string representation of this operator. -/
+protected extern_def toString : Op → String
 
 instance : GetElem Op Nat Term fun op i => i < op.getNumIndices where
   getElem op i h := op.get ⟨i, h⟩
@@ -256,103 +247,99 @@ end Op
 
 namespace Term
 
-extern! "term"
-  def null : Unit → Term
+/-- The null term. -/
+extern_def null : Unit → Term
 
 instance : Inhabited Term := ⟨null ()⟩
 
-extern! "term"
-  /-- Syntactic equality operator. -/
-  protected def beq : Term → Term → Bool
+/-- Syntactic equality operator. -/
+protected extern_def beq : Term → Term → Bool
 
 instance : BEq Term := ⟨Term.beq⟩
 
-extern! "term"
-  protected def hash : Term → UInt64
+protected extern_def hash : Term → UInt64
 
 instance : Hashable Term := ⟨Term.hash⟩
 
-extern! "term"
+/-- Determine if this term is nullary. -/
+extern_def isNull : Term → Bool
 
-  /-- Determine if this term is nullary. -/
-  def isNull : Term → Bool
+/-- Get the kind of this term. -/
+extern_def getKind : Term → Kind
 
-  /-- Get the kind of this term. -/
-  def getKind : Term → Kind
+/-- Get the sort of this term. -/
+extern_def getSort : Term → cvc5.Sort
 
-  /-- Get the sort of this term. -/
-  def getSort : Term → cvc5.Sort
+/-- Determine if this term has an operator. -/
+extern_def hasOp : Term → Bool
 
-  /-- Determine if this term has an operator. -/
-  def hasOp : Term → Bool
+/-- Determine if this term has a symbol (a name).
 
-  /-- Determine if this term has a symbol (a name).
+For example, free constants and variables have symbols.
+-/
+extern_def hasSymbol : Term → Bool
 
-  For example, free constants and variables have symbols.
-  -/
-  def hasSymbol : Term → Bool
+/-- Get the id of this term. -/
+extern_def getId : Term → Nat
 
-  /-- Get the id of this term. -/
-  def getId : Term → Nat
+/-- Get the number of children of this term. -/
+extern_def getNumChildren : Term → Nat
 
-  /-- Get the number of children of this term. -/
-  def getNumChildren : Term → Nat
+/-- Is this term a skolem? -/
+extern_def isSkolem : Term → Bool
 
-  /-- Is this term a skolem? -/
-  def isSkolem : Term → Bool
+/-- Get the child term of this term at a given index. -/
+protected extern_def get : (t : Term) → Fin t.getNumChildren → Term
 
-  /-- Get the child term of this term at a given index. -/
-  protected def get : (t : Term) → Fin t.getNumChildren → Term
+/-- Get the operator of a term with an operator.
 
-  /-- Get the operator of a term with an operator.
+Requires that this term has an operator (see `hasOp`).
+-/
+extern_def!? getOp : Term → Except Error Op
 
-  Requires that this term has an operator (see `hasOp`).
-  -/
-  def !? getOp : Term → Except Error Op
+/-- Get the value of a Boolean term as a native Boolean value.
 
-  /-- Get the value of a Boolean term as a native Boolean value.
+Requires `term` to have sort Bool.
+-/
+extern_def!? getBooleanValue : Term → Except Error Bool
 
-  Requires `term` to have sort Bool.
-  -/
-  def !? getBooleanValue : Term → Except Error Bool
+/-- Get the string representation of a bit-vector value.
 
-  /-- Get the string representation of a bit-vector value.
+Requires `term` to have a bit-vector sort.
 
-  Requires `term` to have a bit-vector sort.
+- `base`: `2` for binary, `10` for decimal, and `16` for hexadecimal.
+-/
+extern_def!? getBitVectorValue : Term → UInt32 → Except Error String
 
-  - `base`: `2` for binary, `10` for decimal, and `16` for hexadecimal.
-  -/
-  def !? getBitVectorValue : Term → UInt32 → Except Error String
+/-- Get the native integral value of an integral value. -/
+extern_def!? getIntegerValue : Term → Except Error Int
 
-  /-- Get the native integral value of an integral value. -/
-  def !? getIntegerValue : Term → Except Error Int
+/-- Get the native rational value of a real, rational-compatible value. -/
+extern_def!? getRationalValue : Term → Except Error Lean.Rat
 
-  /-- Get the native rational value of a real, rational-compatible value. -/
-  def !? getRationalValue : Term → Except Error Lean.Rat
+/-- Get the symbol of this term.
 
-  /-- Get the symbol of this term.
+Requires that this term has a symbol (see `hasSymbol`).
 
-  Requires that this term has a symbol (see `hasSymbol`).
+The symbol of the term is the string that was provided when constructing it *via*
+`TermManager.mkConst` or `TermManager.mkVar`.
+-/
+extern_def!? getSymbol : Term → Except Error String
 
-  The symbol of the term is the string that was provided when constructing it *via*
-  `TermManager.mkConst` or `TermManager.mkVar`.
-  -/
-  def !? getSymbol : Term → Except Error String
+/-- Get skolem identifier of this term.
 
-  /-- Get skolem identifier of this term.
+Requires `isSkolem`.
+-/
+extern_def!? getSkolemId : Term → Except Error SkolemId
 
-  Requires `isSkolem`.
-  -/
-  def !? getSkolemId : Term → Except Error SkolemId
+/-- Get the skolem indices of this term.
 
-  /-- Get the skolem indices of this term.
+Requires `isSkolem`.
 
-  Requires `isSkolem`.
-
-  Returns the skolem indices of this term. This is a list of terms that the skolem function is
-  indexed by. For example, the array diff skolem `SkolemId.ARRAY_DEQ_DIFF` is indexed by two arrays.
-  -/
-  def !? getSkolemIndices : Term → Except Error (Array Term)
+Returns the skolem indices of this term. This is a list of terms that the skolem function is indexed
+by. For example, the array diff skolem `SkolemId.ARRAY_DEQ_DIFF` is indexed by two arrays.
+-/
+extern_def!? getSkolemIndices : Term → Except Error (Array Term)
 
 instance : GetElem Term Nat Term fun t i => i < t.getNumChildren where
   getElem t i h := t.get ⟨i, h⟩
@@ -380,18 +367,17 @@ def getChildren (t : Term) : Array Term := Id.run do
     cts := cts.push ct
   cts
 
-extern! "term"
-  /-- Boolean negation. -/
-  protected def !? not : Term → Except Error Term
+/-- Boolean negation. -/
+protected extern_def!? not : Term → Except Error Term
 
-  /-- Boolean and. -/
-  protected def !? and : Term → Term → Except Error Term
+/-- Boolean and. -/
+protected extern_def!? and : Term → Term → Except Error Term
 
-  /-- Boolean or. -/
-  protected def !? or : Term → Term → Except Error Term
+/-- Boolean or. -/
+protected extern_def!? or : Term → Term → Except Error Term
 
-  /-- A string representation of this term. -/
-  protected def toString : Term → String
+/-- A string representation of this term. -/
+protected extern_def toString : Term → String
 
 instance : ToString Term := ⟨Term.toString⟩
 
@@ -399,38 +385,36 @@ end Term
 
 namespace Proof
 
-extern! "proof"
-  def null : Unit → Proof
+/-- The null proof. -/
+extern_def null : Unit → Proof
 
 instance : Inhabited Proof := ⟨null ()⟩
 
-extern! "proof"
-  /-- The proof rule used by the root step of the proof. -/
-  def getRule : Proof → ProofRule
+/-- The proof rule used by the root step of the proof. -/
+extern_def getRule : Proof → ProofRule
 
-  /-- The proof rewrite rule used by the root step of the proof. -/
-  def getRewriteRule : Proof → ProofRewriteRule
+/-- The proof rewrite rule used by the root step of the proof. -/
+extern_def getRewriteRule : Proof → ProofRewriteRule
 
-  /-- The conclusion of the root step of the proof. -/
-  def getResult : Proof → Term
+/-- The conclusion of the root step of the proof. -/
+extern_def getResult : Proof → Term
 
-  /-- The premises of the root step of the proof. -/
-  def getChildren : Proof → Array Proof
+/-- The premises of the root step of the proof. -/
+extern_def getChildren : Proof → Array Proof
 
-  /-- The arguments of the root step of the proof as a vector of terms.
+/-- The arguments of the root step of the proof as a vector of terms.
 
-  Some of those terms might be strings.
-  -/
-  def getArguments : Proof → Array Term
+Some of those terms might be strings.
+-/
+extern_def getArguments : Proof → Array Term
 
-  /-- Operator overloading for referential equality of two proofs. -/
-  protected def beq : Proof → Proof → Bool
+/-- Operator overloading for referential equality of two proofs. -/
+protected extern_def beq : Proof → Proof → Bool
 
 instance : BEq Proof := ⟨Proof.beq⟩
 
-extern! "proof"
-  /-- Hash function for proofs. -/
-  protected def hash : Proof → UInt64
+/-- Hash function for proofs. -/
+protected extern_def hash : Proof → UInt64
 
 instance : Hashable Proof := ⟨Proof.hash⟩
 
@@ -438,123 +422,122 @@ end Proof
 
 namespace TermManager
 
-extern! "termManager"
-  /-- Constructor. -/
-  def new : BaseIO TermManager
+/-- Constructor. -/
+extern_def new : BaseIO TermManager
 
-  /-- Get the Boolean sort. -/
-  def getBooleanSort : TermManager → cvc5.Sort
+/-- Get the Boolean sort. -/
+extern_def getBooleanSort : TermManager → cvc5.Sort
 
-  /-- Get the Integer sort. -/
-  def getIntegerSort : TermManager → cvc5.Sort
+/-- Get the Integer sort. -/
+extern_def getIntegerSort : TermManager → cvc5.Sort
 
-  /-- Get the Real sort. -/
-  def getRealSort : TermManager → cvc5.Sort
+/-- Get the Real sort. -/
+extern_def getRealSort : TermManager → cvc5.Sort
 
-  /-- Get the regular expression sort. -/
-  def getRegExpSort : TermManager → cvc5.Sort
+/-- Get the regular expression sort. -/
+extern_def getRegExpSort : TermManager → cvc5.Sort
 
-  /-- Get the rounding mode sort. -/
-  def getRoundingModeSort : TermManager → cvc5.Sort
+/-- Get the rounding mode sort. -/
+extern_def getRoundingModeSort : TermManager → cvc5.Sort
 
-  /-- Get the string sort. -/
-  def getStringSort : TermManager → cvc5.Sort
+/-- Get the string sort. -/
+extern_def getStringSort : TermManager → cvc5.Sort
 
-  /-- Create an array sort.
+/-- Create an array sort.
 
-  - `indexSort` The array index sort.
-  - `elemSort` The array element sort.
-  -/
-  def !? mkArraySort : TermManager → (indexSort elemSort : cvc5.Sort) → Except Error cvc5.Sort
+- `indexSort` The array index sort.
+- `elemSort` The array element sort.
+-/
+extern_def!? mkArraySort : TermManager → (indexSort elemSort : cvc5.Sort) → Except Error cvc5.Sort
 
-  /-- Create a bit-vector sort.
+/-- Create a bit-vector sort.
 
-  - `size` The bit-width of the bit-vector sort.
-  -/
-  def !? mkBitVectorSort : TermManager → (size : UInt32) → Except Error cvc5.Sort
+- `size` The bit-width of the bit-vector sort.
+-/
+extern_def!? mkBitVectorSort : TermManager → (size : UInt32) → Except Error cvc5.Sort
 
-  /-- Create a floating-point sort.
+/-- Create a floating-point sort.
 
-  - `exp` The bit-width of the exponent of the floating-point sort.
-  - `sig` The bit-width of the significand of the floating-point sort.
-  -/
-  def !? mkFloatingPointSort : TermManager → (exp sig : UInt32) → Except Error cvc5.Sort
+- `exp` The bit-width of the exponent of the floating-point sort.
+- `sig` The bit-width of the significand of the floating-point sort.
+-/
+extern_def!? mkFloatingPointSort : TermManager → (exp sig : UInt32) → Except Error cvc5.Sort
 
-  /-- Create function sort.
+/-- Create function sort.
 
-  - `sorts` The sort of the function arguments.
-  - `codomain` The sort of the function return value.
-  -/
-  def !? mkFunctionSort
-  : TermManager → (sorts : Array cvc5.Sort) → (codomain : cvc5.Sort) → Except Error cvc5.Sort
+- `sorts` The sort of the function arguments.
+- `codomain` The sort of the function return value.
+-/
+extern_def!? mkFunctionSort
+: TermManager → (sorts : Array cvc5.Sort) → (codomain : cvc5.Sort) → Except Error cvc5.Sort
 
-  /-- Create a Boolean constant.
+/-- Create a Boolean constant.
 
-  - `b`: The Boolean constant.
-  -/
-  def mkBoolean : TermManager → Bool → Term
+- `b`: The Boolean constant.
+-/
+extern_def mkBoolean : TermManager → Bool → Term
 
-  /-- Create an integer-value term. -/
-  private def mkIntegerFromString : TermManager → String → Except Error Term
-  with
-    mkInteger (tm : TermManager) : Int → Term :=
-      Error.unwrap! ∘ tm.mkIntegerFromString ∘ toString
+/-- Create an integer-value term. -/
+private extern_def mkIntegerFromString : TermManager → String → Except Error Term
+with
+  mkInteger (tm : TermManager) : Int → Term :=
+    Error.unwrap! ∘ tm.mkIntegerFromString ∘ toString
 
-  /-- Create operator of Kind:
+/-- Create operator of Kind:
 
-  - `Kind.BITVECTOR_EXTRACT`
-  - `Kind.BITVECTOR_REPEAT`
-  - `Kind.BITVECTOR_ROTATE_LEFT`
-  - `Kind.BITVECTOR_ROTATE_RIGHT`
-  - `Kind.BITVECTOR_SIGN_EXTEND`
-  - `Kind.BITVECTOR_ZERO_EXTEND`
-  - `Kind.DIVISIBLE`
-  - `Kind.FLOATINGPOINT_TO_FP_FROM_FP`
-  - `Kind.FLOATINGPOINT_TO_FP_FROM_IEEE_BV`
-  - `Kind.FLOATINGPOINT_TO_FP_FROM_REAL`
-  - `Kind.FLOATINGPOINT_TO_FP_FROM_SBV`
-  - `Kind.FLOATINGPOINT_TO_FP_FROM_UBV`
-  - `Kind.FLOATINGPOINT_TO_SBV`
-  - `Kind.FLOATINGPOINT_TO_UBV`
-  - `Kind.INT_TO_BITVECTOR`
-  - `Kind.TUPLE_PROJECT`
+- `Kind.BITVECTOR_EXTRACT`
+- `Kind.BITVECTOR_REPEAT`
+- `Kind.BITVECTOR_ROTATE_LEFT`
+- `Kind.BITVECTOR_ROTATE_RIGHT`
+- `Kind.BITVECTOR_SIGN_EXTEND`
+- `Kind.BITVECTOR_ZERO_EXTEND`
+- `Kind.DIVISIBLE`
+- `Kind.FLOATINGPOINT_TO_FP_FROM_FP`
+- `Kind.FLOATINGPOINT_TO_FP_FROM_IEEE_BV`
+- `Kind.FLOATINGPOINT_TO_FP_FROM_REAL`
+- `Kind.FLOATINGPOINT_TO_FP_FROM_SBV`
+- `Kind.FLOATINGPOINT_TO_FP_FROM_UBV`
+- `Kind.FLOATINGPOINT_TO_SBV`
+- `Kind.FLOATINGPOINT_TO_UBV`
+- `Kind.INT_TO_BITVECTOR`
+- `Kind.TUPLE_PROJECT`
 
-  See `cvc5.Kind` for a description of the parameters.
+See `cvc5.Kind` for a description of the parameters.
 
-  - `kind` The kind of the operator.
-  - `args` The arguments (indices) of the operator.
+- `kind` The kind of the operator.
+- `args` The arguments (indices) of the operator.
 
-  If `args` is empty, the `Op` simply wraps the `cvc5.Kind`. The `Kind` can be used in
-  `Solver.mkTerm` directly without creating an `Op` first.
-  -/
-  def !? mkOpOfIndices : TermManager → (kind : Kind) → (args : Array Nat) → Except Error Op
+If `args` is empty, the `Op` simply wraps the `cvc5.Kind`. The `Kind` can be used in
+`Solver.mkTerm` directly without creating an `Op` first.
+-/
+extern_def!? mkOpOfIndices : TermManager → (kind : Kind) → (args : Array Nat) → Except Error Op
 
-  /-- Create operator of kind:
+/-- Create operator of kind:
 
-  - `Kind.DIVISIBLE` (to support arbitrary precision integers)
+- `Kind.DIVISIBLE` (to support arbitrary precision integers)
 
-  See `cvc5.Kind` for a description of the parameters.
+See `cvc5.Kind` for a description of the parameters.
 
-  - `kind` The kind of the operator.
-  - `arg` The string argument to this operator.
-  -/
-  def !? mkOpOfString : TermManager → (kind : Kind) → (arg : String) → Except Error Op
+- `kind` The kind of the operator.
+- `arg` The string argument to this operator.
+-/
+extern_def!? mkOpOfString : TermManager → (kind : Kind) → (arg : String) → Except Error Op
 
-  /-- Create n-ary term of given kind.
+/-- Create n-ary term of given kind.
 
-  - `kind` The kind of the term.
-  - `children` The children of the term.
-  -/
-  def !? mkTerm : TermManager → (kind : Kind) → (children : Array Term := #[]) → Except Error Term
+- `kind` The kind of the term.
+- `children` The children of the term.
+-/
+extern_def!? mkTerm : TermManager → (kind : Kind) → (children : Array Term := #[]) → Except Error Term
 
-  /-- Create n-ary term of given kind from a given operator.
+/-- Create n-ary term of given kind from a given operator.
 
-  Create operators with `mkOp`.
+Create operators with `mkOp`.
 
-  - `op` The operator.
-  - `children` The children of the term.
-  -/
-  def !? mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
+- `op` The operator.
+- `children` The children of the term.
+-/
+extern_def!? mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
 
 end TermManager
 
@@ -574,55 +557,53 @@ private def err (e : Error) : SolverT m α := throw e
 @[export solver_errOfString]
 private def errorOfString (msg : String) : SolverT m α := throw (.error msg)
 
-extern! "solver"
+/-- Constructor.
 
-  /-- Constructor.
+Constructs solver instance from a given term manager instance.
 
-  Constructs solver instance from a given term manager instance.
+- `tm`: The associated term manager.
+-/
+private extern_def new : TermManager → Solver
 
-  - `tm`: The associated term manager.
-  -/
-  private def new : TermManager → Solver
+/-- Get a string representation of the version of this solver. -/
+extern_def getVersion : SolverT m String
 
-  /-- Get a string representation of the version of this solver. -/
-  def getVersion : SolverT m String
+/-- Set option.
 
-  /-- Set option.
+- `option`: The option name.
+- `value`: The option value.
+-/
+extern_def setOption (option value : String) : SolverT m Unit
 
-  - `option`: The option name.
-  - `value`: The option value.
-  -/
-  def setOption (option value : String) : SolverT m Unit
+/-- Assert a formula.
 
-  /-- Assert a formula.
+- `term`: The formula to assert.
+-/
+extern_def assertFormula : Term → SolverT m Unit
 
-  - `term`: The formula to assert.
-  -/
-  def assertFormula : Term → SolverT m Unit
+/-- Check satisfiability. -/
+extern_def checkSat : SolverT m Result
 
-  /-- Check satisfiability. -/
-  def checkSat : SolverT m Result
+/-- Get a proof associated with the most recent call to `checkSat`.
 
-  /-- Get a proof associated with the most recent call to `checkSat`.
+Requires to enable option `produce-proofs`.
+-/
+extern_def getProof : SolverT m (Array Proof)
 
-  Requires to enable option `produce-proofs`.
-  -/
-  def getProof : SolverT m (Array Proof)
+/-- Prints a proof as a string in a selected proof format mode.
 
-  /-- Prints a proof as a string in a selected proof format mode.
+Other aspects of printing are taken from the solver options.
 
-  Other aspects of printing are taken from the solver options.
+- `proof`: A proof, usually obtained from `getProof`.
+-/
+extern_def proofToString : Proof → SolverT m String
 
-  - `proof`: A proof, usually obtained from `getProof`.
-  -/
-  def proofToString : Proof → SolverT m String
+/-- Parse a string containing SMT-LIB commands.
 
-  /-- Parse a string containing SMT-LIB commands.
-
-  Commands that produce a result such as `(check-sat)`, `(get-model)`, ... are executed but the
-  results are ignored.
-  -/
-  def parse : String → SolverT m Unit
+Commands that produce a result such as `(check-sat)`, `(get-model)`, ... are executed but the
+results are ignored.
+-/
+extern_def parse : String → SolverT m Unit
 
 /-- Run a `query` given a term manager `tm`. -/
 def run (tm : TermManager) (query : SolverT m α) : m (Except Error α) :=

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -16,6 +16,7 @@ namespace cvc5
 
 private opaque ResultImpl : NonemptyType.{0}
 
+/-- Encapsulation of a three-valued solver result, with explanations. -/
 def Result : Type := ResultImpl.type
 
 instance Result.instNonemptyResult : Nonempty Result := ResultImpl.property
@@ -24,6 +25,7 @@ private opaque SortImpl : NonemptyType.{0}
 
 end cvc5
 
+/-- The sort of a cvc5 term. -/
 def cvc5.Sort : Type := cvc5.SortImpl.type
 
 namespace cvc5
@@ -32,28 +34,41 @@ instance Sort.instNonemptySort : Nonempty cvc5.Sort := SortImpl.property
 
 private opaque OpImpl : NonemptyType.{0}
 
+/-- A cvc5 operator.
+
+An operator is a term that represents certain operators, instantiated with its required parameters,
+*e.g.*, a `Term` of kind `Kind.BITVECTOR_EXTRACT`.
+-/
 def Op : Type := OpImpl.type
 
 instance Op.instNonemptyOp : Nonempty Op := OpImpl.property
 
 private opaque TermImpl : NonemptyType.{0}
 
+/-- A cvc5 term. -/
 def Term : Type := TermImpl.type
 
 instance Term.instNonemptyTerm : Nonempty Term := TermImpl.property
 
 private opaque ProofImpl : NonemptyType.{0}
 
+/-- A cvc5 proof.
+
+Proofs are trees and every proof object corresponds to the root step of a proof. The branches of the
+root step are the premises of the step.
+-/
 def Proof : Type := ProofImpl.type
 
 instance Proof.instNonemptyProof : Nonempty Proof := ProofImpl.property
 
 private opaque TermManagerImpl : NonemptyType.{0}
 
+/-- Manager for cvc5 terms. -/
 def TermManager : Type := TermManagerImpl.type
 
 instance TermManager.instNonemptyTermManager : Nonempty TermManager := TermManagerImpl.property
 
+/-- Error type. -/
 inductive Error where
   | missingValue
   | error (msg : String)
@@ -64,19 +79,24 @@ deriving Repr
 
 private opaque SolverImpl : NonemptyType.{0}
 
+/-- A cvc5 solver. -/
 def Solver : Type := SolverImpl.type
 
 instance Solver.instNonemptySolver : Nonempty Solver := SolverImpl.property
 
+/-- Solver error/state-monad transformer. -/
 abbrev SolverT m := ExceptT Error (StateT Solver m)
 
+/-- Solver error/state-monad wrapped in `IO`. -/
 abbrev SolverM := SolverT IO
 
 namespace Error
 
+/-- String representation of an error. -/
 protected def toString : Error → String :=
   toString ∘ repr
 
+/-- Panics on errors, otherwise yields the `ok` result. -/
 def unwrap! [Inhabited α] : Except Error α → α
 | .ok a => a
 | .error e => panic! e.toString
@@ -89,9 +109,19 @@ end Error
 namespace Result
 
 extern! "result"
+
+  /-- True if this result is from a satisfiable `checkSat` or `checkSatAssuming` query. -/
   def isSat : Result → Bool
+
+  /-- True if this result is from a unsatisfiable `checkSat` or `checkSatAssuming` query. -/
   def isUnsat : Result → Bool
+
+  /-- True if this result is from a `checkSat` or `checkSatAssuming` query and cvc5 was not able to
+  determine (un)satisfiability.
+  -/
   def isUnknown : Result → Bool
+
+  /-- A string representation of this result. -/
   protected def toString : Result → String
 
 instance : ToString Result := ⟨Result.toString⟩
@@ -135,21 +165,37 @@ extern! "sort"
 instance : Inhabited cvc5.Sort := ⟨null ()⟩
 
 extern! "sort"
+  /-- Comparison for structural equality. -/
   protected def beq : cvc5.Sort → cvc5.Sort → Bool
 
 instance : BEq cvc5.Sort := ⟨Sort.beq⟩
 
 extern! "sort"
+  /-- Hash function for cvc5 sorts. -/
   protected def hash : cvc5.Sort → UInt64
 
 instance : Hashable cvc5.Sort := ⟨Sort.hash⟩
 
 extern! "sort"
+
+  /-- Get the kind of this sort. -/
   def getKind : cvc5.Sort → SortKind
+
+  /-- Determine if this is the integer sort (SMT-LIB: `Int`). -/
   def isInteger : cvc5.Sort → Bool
+
+  /-- Determine if this is a function sort. -/
+  protected def isFunction : cvc5.Sort → Bool
+
+  /-- A string representation of this sort. -/
   protected def toString : cvc5.Sort → String
 
-/-- The domain sorts of a function sort. -/
+/-- Get the symbol of this sort.
+
+The symbol of this sort is the string that was provided when consrtucting it *via* one of
+`Solver.mkUninterpretedSort`, `Solver.mkUnresolvedSort`, or
+`Solver.mkUninterpretedSortConstructorSort`.
+-/
 extern_def!? "sort"
   getSymbol : cvc5.Sort → Except Error String
 
@@ -161,7 +207,7 @@ extern_def!? "sort"
 extern_def!? "sort"
   getFunctionCodomainSort : cvc5.Sort → Except Error cvc5.Sort
 
-/-- The codomain sort of a function sort. -/
+/-- The bit-width of the bit-vector sort. -/
 extern_def!? "sort"
   getBitVectorSize : cvc5.Sort → Except Error UInt32
 
@@ -178,16 +224,29 @@ extern! "op"
 instance : Inhabited Op := ⟨null ()⟩
 
 extern! "op"
+  /-- Syntactic equality operator. -/
   protected def beq : Op → Op → Bool
 
 instance : BEq Op := ⟨Op.beq⟩
 
 extern! "op"
+
+  /-- Get the kind of this operator. -/
   def getKind : Op → Kind
+
+  /-- Determine if this operator is nullary. -/
   def isNull : Op → Bool
+
+  /-- Determine if this operator is indexed. -/
   def isIndexed : Op → Bool
+
+  /-- Get the number of indices of this operator. -/
   def getNumIndices : Op → Nat
+
+  /-- Get the index at position `i` of an indexed operator. -/
   protected def get : (op : Op) → Fin op.getNumIndices → Term
+
+  /-- Get the string representation of this operator. -/
   protected def toString : Op → String
 
 instance : GetElem Op Nat Term fun op i => i < op.getNumIndices where
@@ -205,25 +264,54 @@ extern! "term"
 instance : Inhabited Term := ⟨null ()⟩
 
 extern! "term"
+  /-- Syntactic equality operator. -/
   protected def beq : Term → Term → Bool
 
 instance : BEq Term := ⟨Term.beq⟩
 
 extern! "hash"
+  /-- Hash function for terms. -/
   protected def hash : Term → UInt64
 
 instance : Hashable Term := ⟨Term.hash⟩
 
 extern! "term"
+
+  /-- Determine if this term is nullary. -/
   def isNull : Term → Bool
+
+  /-- Get the kind of this term. -/
   def getKind : Term → Kind
+
+  /-- Get the sort of this term. -/
   def getSort : Term → cvc5.Sort
-  def getOp : Term → Op
+
+  /-- Determine if this term has an operator. -/
+  def hasOp : Term → Bool
+
+  /-- Determine if this term has a symbol (a name).
+
+  For example, free constants and variables have symbols.
+  -/
   def hasSymbol : Term → Bool
+
+  /-- Get the id of this term. -/
   def getId : Term → Nat
+
+  /-- Get the number of children of this term. -/
   def getNumChildren : Term → Nat
+
+  /-- Is this term a skolem? -/
   def isSkolem : Term → Bool
+
+  /-- Get the child term of this term at a given index. -/
   protected def get : (t : Term) → Fin t.getNumChildren → Term
+
+/-- Get the operator of a term with an operator.
+
+Requires that this term has an operator (see `hasOp`).
+-/
+extern_def!? "term" getOp : Term → Except Error Op
 
 /-- Get the value of a Boolean term as a native Boolean value.
 
@@ -288,6 +376,7 @@ protected def forIn {β : Type u} [Monad m] (t : Term) (b : β) (f : Term → β
 instance : ForIn m Term Term where
   forIn := Term.forIn
 
+/-- Get the children of a term. -/
 def getChildren (t : Term) : Array Term := Id.run do
   let mut cts := #[]
   for ct in t do
@@ -304,6 +393,7 @@ protected extern_def!? "term" and : Term → Term → Except Error Term
 protected extern_def!? "term" or : Term → Term → Except Error Term
 
 extern! "term"
+  /-- A string representation of this term. -/
   protected def toString : Term → String
 
 instance : ToString Term := ⟨Term.toString⟩
@@ -318,16 +408,31 @@ extern! "proof"
 instance : Inhabited Proof := ⟨null ()⟩
 
 extern! "proof"
+  /-- The proof rule used by the root step of the proof. -/
   def getRule : Proof → ProofRule
+
+  /-- The proof rewrite rule used by the root step of the proof. -/
   def getRewriteRule : Proof → ProofRewriteRule
+
+  /-- The conclusion of the root step of the proof. -/
   def getResult : Proof → Term
+
+  /-- The premises of the root step of the proof. -/
   def getChildren : Proof → Array Proof
+
+  /-- The arguments of the root step of the proof as a vector of terms.
+
+  Some of those terms might be strings.
+  -/
   def getArguments : Proof → Array Term
+
+  /-- Operator overloading for referential equality of two proofs. -/
   protected def beq : Proof → Proof → Bool
 
 instance : BEq Proof := ⟨Proof.beq⟩
 
 extern! "proof"
+  /-- Hash function for proofs. -/
   protected def hash : Proof → UInt64
 
 instance : Hashable Proof := ⟨Proof.hash⟩
@@ -337,18 +442,24 @@ end Proof
 namespace TermManager
 
 extern! "termManager"
+  /-- Constructor. -/
   def new : BaseIO TermManager
 
   /-- Get the Boolean sort. -/
   def getBooleanSort : TermManager → cvc5.Sort
+
   /-- Get the Integer sort. -/
   def getIntegerSort : TermManager → cvc5.Sort
+
   /-- Get the Real sort. -/
   def getRealSort : TermManager → cvc5.Sort
+
   /-- Get the regular expression sort. -/
   def getRegExpSort : TermManager → cvc5.Sort
+
   /-- Get the rounding mode sort. -/
   def getRoundingModeSort : TermManager → cvc5.Sort
+
   /-- Get the string sort. -/
   def getStringSort : TermManager → cvc5.Sort
 
@@ -385,6 +496,10 @@ extern_def!? "termManager"
   : TermManager → (sorts : Array cvc5.Sort) → (codomain : cvc5.Sort) → Except Error cvc5.Sort
 
 extern! "termManager"
+  /-- Create a Boolean constant.
+
+  - `b`: The Boolean constant.
+  -/
   def mkBoolean : TermManager → Bool → Term
 
   /-- Create an integer-value term. -/
@@ -474,15 +589,56 @@ private def err (e : Error) : SolverT m α := throw e
 private def errorOfString (msg : String) : SolverT m α := throw (.error msg)
 
 extern! "solver"
+
+  /-- Constructor.
+
+  Constructs solver instance from a given term manager instance.
+
+  - `tm`: The associated term manager.
+  -/
   private def new : TermManager → Solver
+
+  /-- Get a string representation of the version of this solver. -/
   def getVersion : SolverT m String
+
+  /-- Set option.
+
+  - `option`: The option name.
+  - `value`: The option value.
+  -/
   def setOption (option value : String) : SolverT m Unit
+
+  /-- Assert a formula.
+
+  - `term`: The formula to assert.
+  -/
   def assertFormula : Term → SolverT m Unit
+
+  /-- Check satisfiability. -/
   def checkSat : SolverT m Result
+
+  /-- Get a proof associated with the most recent call to `checkSat`.
+
+  Requires to enable option `produce-proofs`.
+  -/
   def getProof : SolverT m (Array Proof)
+
+  /-- Prints a proof as a string in a selected proof format mode.
+
+  Other aspects of printing are taken from the solver options.
+
+  - `proof`: A proof, usually obtained from `getProof`.
+  -/
   def proofToString : Proof → SolverT m String
+
+  /-- Parse a string containing SMT-LIB commands.
+
+  Commands that produce a result such as `(check-sat)`, `(get-model)`, ... are executed but the
+  results are ignored.
+  -/
   def parse : String → SolverT m Unit
 
+/-- Run a `query` given a term manager `tm`. -/
 def run (tm : TermManager) (query : SolverT m α) : m (Except Error α) :=
   return match ← ExceptT.run query (new tm) with
   | (.ok x, _) => .ok x

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -190,26 +190,22 @@ extern! "sort"
   /-- A string representation of this sort. -/
   protected def toString : cvc5.Sort → String
 
-/-- Get the symbol of this sort.
+  /-- Get the symbol of this sort.
 
-The symbol of this sort is the string that was provided when consrtucting it *via* one of
-`Solver.mkUninterpretedSort`, `Solver.mkUnresolvedSort`, or
-`Solver.mkUninterpretedSortConstructorSort`.
--/
-extern_def!? "sort"
-  getSymbol : cvc5.Sort → Except Error String
+  The symbol of this sort is the string that was provided when consrtucting it *via* one of
+  `Solver.mkUninterpretedSort`, `Solver.mkUnresolvedSort`, or
+  `Solver.mkUninterpretedSortConstructorSort`.
+  -/
+  def !? getSymbol : cvc5.Sort → Except Error String
 
-/-- The domain sorts of a function sort. -/
-extern_def!? "sort"
-  getFunctionDomainSorts : cvc5.Sort → Except Error (Array cvc5.Sort)
+  /-- The domain sorts of a function sort. -/
+  def !? getFunctionDomainSorts : cvc5.Sort → Except Error (Array cvc5.Sort)
 
-/-- The codomain sort of a function sort. -/
-extern_def!? "sort"
-  getFunctionCodomainSort : cvc5.Sort → Except Error cvc5.Sort
+  /-- The codomain sort of a function sort. -/
+  def !? getFunctionCodomainSort : cvc5.Sort → Except Error cvc5.Sort
 
-/-- The bit-width of the bit-vector sort. -/
-extern_def!? "sort"
-  getBitVectorSize : cvc5.Sort → Except Error UInt32
+  /-- The bit-width of the bit-vector sort. -/
+  def !? getBitVectorSize : cvc5.Sort → Except Error UInt32
 
 instance : ToString cvc5.Sort := ⟨Sort.toString⟩
 instance : Repr cvc5.Sort := ⟨fun self _ => self.toString⟩
@@ -307,55 +303,55 @@ extern! "term"
   /-- Get the child term of this term at a given index. -/
   protected def get : (t : Term) → Fin t.getNumChildren → Term
 
-/-- Get the operator of a term with an operator.
+  /-- Get the operator of a term with an operator.
 
-Requires that this term has an operator (see `hasOp`).
--/
-extern_def!? "term" getOp : Term → Except Error Op
+  Requires that this term has an operator (see `hasOp`).
+  -/
+  def !? getOp : Term → Except Error Op
 
-/-- Get the value of a Boolean term as a native Boolean value.
+  /-- Get the value of a Boolean term as a native Boolean value.
 
-Requires `term` to have sort Bool.
--/
-extern_def!? "term" getBooleanValue : Term → Except Error Bool
+  Requires `term` to have sort Bool.
+  -/
+  def !? getBooleanValue : Term → Except Error Bool
 
-/-- Get the string representation of a bit-vector value.
+  /-- Get the string representation of a bit-vector value.
 
-Requires `term` to have a bit-vector sort.
+  Requires `term` to have a bit-vector sort.
 
-- `base`: `2` for binary, `10` for decimal, and `16` for hexadecimal.
--/
-extern_def!? "term" getBitVectorValue : Term → UInt32 → Except Error String
+  - `base`: `2` for binary, `10` for decimal, and `16` for hexadecimal.
+  -/
+  def !? getBitVectorValue : Term → UInt32 → Except Error String
 
-/-- Get the native integral value of an integral value. -/
-extern_def!? "term" getIntegerValue : Term → Except Error Int
+  /-- Get the native integral value of an integral value. -/
+  def !? getIntegerValue : Term → Except Error Int
 
-/-- Get the native rational value of a real, rational-compatible value. -/
-extern_def!? "term" getRationalValue : Term → Except Error Lean.Rat
+  /-- Get the native rational value of a real, rational-compatible value. -/
+  def !? getRationalValue : Term → Except Error Lean.Rat
 
-/-- Get the symbol of this term.
+  /-- Get the symbol of this term.
 
-Requires that this term has a symbol (see `hasSymbol`).
+  Requires that this term has a symbol (see `hasSymbol`).
 
-The symbol of the term is the string that was provided when constructing it *via*
-`TermManager.mkConst` or `TermManager.mkVar`.
--/
-extern_def!? "term" getSymbol : Term → Except Error String
+  The symbol of the term is the string that was provided when constructing it *via*
+  `TermManager.mkConst` or `TermManager.mkVar`.
+  -/
+  def !? getSymbol : Term → Except Error String
 
-/-- Get skolem identifier of this term.
+  /-- Get skolem identifier of this term.
 
-Requires `isSkolem`.
--/
-extern_def!? "term" getSkolemId : Term → Except Error SkolemId
+  Requires `isSkolem`.
+  -/
+  def !? getSkolemId : Term → Except Error SkolemId
 
-/-- Get the skolem indices of this term.
+  /-- Get the skolem indices of this term.
 
-Requires `isSkolem`.
+  Requires `isSkolem`.
 
-Returns the skolem indices of this term. This is a list of terms that the skolem function is
-indexed by. For example, the array diff skolem `SkolemId.ARRAY_DEQ_DIFF` is indexed by two arrays.
--/
-extern_def!? "term" getSkolemIndices : Term → Except Error (Array Term)
+  Returns the skolem indices of this term. This is a list of terms that the skolem function is
+  indexed by. For example, the array diff skolem `SkolemId.ARRAY_DEQ_DIFF` is indexed by two arrays.
+  -/
+  def !? getSkolemIndices : Term → Except Error (Array Term)
 
 instance : GetElem Term Nat Term fun t i => i < t.getNumChildren where
   getElem t i h := t.get ⟨i, h⟩
@@ -383,16 +379,16 @@ def getChildren (t : Term) : Array Term := Id.run do
     cts := cts.push ct
   cts
 
-/-- Boolean negation. -/
-protected extern_def!? "term" not : Term → Except Error Term
-
-/-- Boolean and. -/
-protected extern_def!? "term" and : Term → Term → Except Error Term
-
-/-- Boolean or. -/
-protected extern_def!? "term" or : Term → Term → Except Error Term
-
 extern! "term"
+  /-- Boolean negation. -/
+  protected def !? not : Term → Except Error Term
+
+  /-- Boolean and. -/
+  protected def !? and : Term → Term → Except Error Term
+
+  /-- Boolean or. -/
+  protected def !? or : Term → Term → Except Error Term
+
   /-- A string representation of this term. -/
   protected def toString : Term → String
 
@@ -463,39 +459,34 @@ extern! "termManager"
   /-- Get the string sort. -/
   def getStringSort : TermManager → cvc5.Sort
 
-/-- Create an array sort.
+  /-- Create an array sort.
 
-- `indexSort` The array index sort.
-- `elemSort` The array element sort.
--/
-extern_def!? "termManager"
-  mkArraySort : TermManager → (indexSort elemSort : cvc5.Sort) → Except Error cvc5.Sort
+  - `indexSort` The array index sort.
+  - `elemSort` The array element sort.
+  -/
+  def !? mkArraySort : TermManager → (indexSort elemSort : cvc5.Sort) → Except Error cvc5.Sort
 
-/-- Create a bit-vector sort.
+  /-- Create a bit-vector sort.
 
-- `size` The bit-width of the bit-vector sort.
--/
-extern_def!? "termManager"
-  mkBitVectorSort : TermManager → (size : UInt32) → Except Error cvc5.Sort
+  - `size` The bit-width of the bit-vector sort.
+  -/
+  def !? mkBitVectorSort : TermManager → (size : UInt32) → Except Error cvc5.Sort
 
-/-- Create a floating-point sort.
+  /-- Create a floating-point sort.
 
-- `exp` The bit-width of the exponent of the floating-point sort.
-- `sig` The bit-width of the significand of the floating-point sort.
--/
-extern_def!? "termManager"
-  mkFloatingPointSort : TermManager → (exp sig : UInt32) → Except Error cvc5.Sort
+  - `exp` The bit-width of the exponent of the floating-point sort.
+  - `sig` The bit-width of the significand of the floating-point sort.
+  -/
+  def !? mkFloatingPointSort : TermManager → (exp sig : UInt32) → Except Error cvc5.Sort
 
-/-- Create function sort.
+  /-- Create function sort.
 
-- `sorts` The sort of the function arguments.
-- `codomain` The sort of the function return value.
--/
-extern_def!? "termManager"
-  mkFunctionSort
+  - `sorts` The sort of the function arguments.
+  - `codomain` The sort of the function return value.
+  -/
+  def !? mkFunctionSort
   : TermManager → (sorts : Array cvc5.Sort) → (codomain : cvc5.Sort) → Except Error cvc5.Sort
 
-extern! "termManager"
   /-- Create a Boolean constant.
 
   - `b`: The Boolean constant.
@@ -510,65 +501,61 @@ extern! "termManager"
     mkInteger? := (mkInteger · · |> Except.toOption)
     mkInteger! := (mkInteger · · |> Error.unwrap!)
 
-/-- Create operator of Kind:
+  /-- Create operator of Kind:
 
-- `Kind.BITVECTOR_EXTRACT`
-- `Kind.BITVECTOR_REPEAT`
-- `Kind.BITVECTOR_ROTATE_LEFT`
-- `Kind.BITVECTOR_ROTATE_RIGHT`
-- `Kind.BITVECTOR_SIGN_EXTEND`
-- `Kind.BITVECTOR_ZERO_EXTEND`
-- `Kind.DIVISIBLE`
-- `Kind.FLOATINGPOINT_TO_FP_FROM_FP`
-- `Kind.FLOATINGPOINT_TO_FP_FROM_IEEE_BV`
-- `Kind.FLOATINGPOINT_TO_FP_FROM_REAL`
-- `Kind.FLOATINGPOINT_TO_FP_FROM_SBV`
-- `Kind.FLOATINGPOINT_TO_FP_FROM_UBV`
-- `Kind.FLOATINGPOINT_TO_SBV`
-- `Kind.FLOATINGPOINT_TO_UBV`
-- `Kind.INT_TO_BITVECTOR`
-- `Kind.TUPLE_PROJECT`
+  - `Kind.BITVECTOR_EXTRACT`
+  - `Kind.BITVECTOR_REPEAT`
+  - `Kind.BITVECTOR_ROTATE_LEFT`
+  - `Kind.BITVECTOR_ROTATE_RIGHT`
+  - `Kind.BITVECTOR_SIGN_EXTEND`
+  - `Kind.BITVECTOR_ZERO_EXTEND`
+  - `Kind.DIVISIBLE`
+  - `Kind.FLOATINGPOINT_TO_FP_FROM_FP`
+  - `Kind.FLOATINGPOINT_TO_FP_FROM_IEEE_BV`
+  - `Kind.FLOATINGPOINT_TO_FP_FROM_REAL`
+  - `Kind.FLOATINGPOINT_TO_FP_FROM_SBV`
+  - `Kind.FLOATINGPOINT_TO_FP_FROM_UBV`
+  - `Kind.FLOATINGPOINT_TO_SBV`
+  - `Kind.FLOATINGPOINT_TO_UBV`
+  - `Kind.INT_TO_BITVECTOR`
+  - `Kind.TUPLE_PROJECT`
 
-See `cvc5.Kind` for a description of the parameters.
+  See `cvc5.Kind` for a description of the parameters.
 
-- `kind` The kind of the operator.
-- `args` The arguments (indices) of the operator.
+  - `kind` The kind of the operator.
+  - `args` The arguments (indices) of the operator.
 
-If `args` is empty, the `Op` simply wraps the `cvc5.Kind`. The `Kind` can be used in
-`Solver.mkTerm` directly without creating an `Op` first.
--/
-extern_def!? "termManager"
-  mkOpOfIndices : TermManager → (kind : Kind) → (args : Array Nat) → Except Error Op
+  If `args` is empty, the `Op` simply wraps the `cvc5.Kind`. The `Kind` can be used in
+  `Solver.mkTerm` directly without creating an `Op` first.
+  -/
+  def !? mkOpOfIndices : TermManager → (kind : Kind) → (args : Array Nat) → Except Error Op
 
-/-- Create operator of kind:
+  /-- Create operator of kind:
 
-- `Kind.DIVISIBLE` (to support arbitrary precision integers)
+  - `Kind.DIVISIBLE` (to support arbitrary precision integers)
 
-See `cvc5.Kind` for a description of the parameters.
+  See `cvc5.Kind` for a description of the parameters.
 
-- `kind` The kind of the operator.
-- `arg` The string argument to this operator.
--/
-extern_def!? "termManager"
-  mkOpOfString : TermManager → (kind : Kind) → (arg : String) → Except Error Op
+  - `kind` The kind of the operator.
+  - `arg` The string argument to this operator.
+  -/
+  def !? mkOpOfString : TermManager → (kind : Kind) → (arg : String) → Except Error Op
 
-/-- Create n-ary term of given kind.
+  /-- Create n-ary term of given kind.
 
-- `kind` The kind of the term.
-- `children` The children of the term.
--/
-extern_def!? "termManager"
-  mkTerm : TermManager → (kind : Kind) → (children : Array Term := #[]) → Except Error Term
+  - `kind` The kind of the term.
+  - `children` The children of the term.
+  -/
+  def !? mkTerm : TermManager → (kind : Kind) → (children : Array Term := #[]) → Except Error Term
 
-/-- Create n-ary term of given kind from a given operator.
+  /-- Create n-ary term of given kind from a given operator.
 
-Create operators with `mkOp`.
+  Create operators with `mkOp`.
 
-- `op` The operator.
-- `children` The children of the term.
--/
-extern_def!? "termManager"
-  mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
+  - `op` The operator.
+  - `children` The children of the term.
+  -/
+  def !? mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
 
 end TermManager
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -56,7 +56,10 @@ instance TermManager.instNonemptyTermManager : Nonempty TermManager := TermManag
 
 inductive Error where
   | missingValue
-  | user_error (msg : String)
+  | error (msg : String)
+  | recoverable (msg : String)
+  | unsupported (msg : String)
+  | option (msg : String)
 deriving Repr
 
 private opaque SolverImpl : NonemptyType.{0}
@@ -71,13 +74,12 @@ abbrev SolverM := SolverT IO
 
 namespace Error
 
-def unwrap! [Inhabited α] : Except Error α → α
-| .ok a => a
-| .error .missingValue => panic! "missing value"
-| .error (.user_error s) => panic! s!"user error: {s}"
-
 protected def toString : Error → String :=
   toString ∘ repr
+
+def unwrap! [Inhabited α] : Except Error α → α
+| .ok a => a
+| .error e => panic! e.toString
 
 instance : ToString Error :=
   ⟨Error.toString⟩

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -32,9 +32,9 @@ extern "C" lean_obj_res except_err(
 //
 // Runs `code`, `return`s an `Except Error α` error on exceptions.
 
-#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN() \
+#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN \
   try {
-#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_END() \
+#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_END \
   } catch (CVC5ApiException& e) { \
     return except_err(lean_box(0), lean_mk_string(e.what())); \
   } catch (char const* e) { \
@@ -80,7 +80,7 @@ extern "C" lean_obj_res solver_errOfString(
 // - `solver`: solver state value.
 // - `code`: the code to run and catch exceptions for.
 
-#define CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN() \
+#define CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN \
   try {
 #define CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver) \
   } catch (CVC5ApiException& e) { \
@@ -230,7 +230,7 @@ extern "C" uint8_t sort_isFunction(lean_obj_arg s)
 
 extern "C" lean_obj_res sort_getFunctionDomainSorts(lean_obj_arg s)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   std::vector<Sort> domains = sort_unbox(s)->getFunctionDomainSorts();
   lean_object* ds = lean_mk_empty_array();
   for (const Sort& domain : domains)
@@ -238,25 +238,25 @@ extern "C" lean_obj_res sort_getFunctionDomainSorts(lean_obj_arg s)
     ds = lean_array_push(ds, sort_box(new Sort(domain)));
   }
   return except_ok(lean_box(0), ds);
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res sort_getFunctionCodomainSort(lean_obj_arg s)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     sort_box(new Sort(sort_unbox(s)->getFunctionCodomainSort()))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res sort_getSymbol(lean_obj_arg s)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     lean_mk_string(sort_unbox(s)->getSymbol().c_str())
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" uint8_t sort_isInteger(lean_obj_arg s)
@@ -266,11 +266,11 @@ extern "C" uint8_t sort_isInteger(lean_obj_arg s)
 
 extern "C" lean_obj_res sort_getBitVectorSize(lean_obj_arg s)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok_u32(
     static_cast<int32_t>(sort_unbox(s)->getBitVectorSize())
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res sort_toString(lean_obj_arg s)
@@ -380,23 +380,23 @@ extern "C" uint8_t term_isNull(lean_obj_arg t)
 
 extern "C" lean_obj_res term_not(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), term_box(new Term(term_unbox(t)->notTerm())));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_and(lean_obj_arg t1, lean_obj_arg t2)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->andTerm(*term_unbox(t2)))));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_or(lean_obj_arg t1, lean_obj_arg t2)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->orTerm(*term_unbox(t2)))));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_toString(lean_obj_arg t)
@@ -416,9 +416,9 @@ extern "C" uint8_t term_hasOp(lean_obj_arg t)
 
 extern "C" lean_obj_arg term_getOp(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), op_box(new Op(term_unbox(t)->getOp())));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_arg term_getSort(lean_obj_arg t)
@@ -438,30 +438,30 @@ extern "C" uint64_t term_hash(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getBooleanValue(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok_bool(bool_box(term_unbox(t)->getBooleanValue()));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_getBitVectorValue(lean_obj_arg t, uint32_t base)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getBitVectorValue(base).c_str()));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_getIntegerValue(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), lean_cstr_to_int(term_unbox(t)->getIntegerValue().c_str()));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res l_Lean_mkRat(lean_obj_arg num, lean_obj_arg den);
 
 extern "C" lean_obj_res term_getRationalValue(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   std::string r = term_unbox(t)->getRealValue();
   size_t i = r.find('/');
   return except_ok(lean_box(0),
@@ -470,7 +470,7 @@ extern "C" lean_obj_res term_getRationalValue(lean_obj_arg t)
       lean_cstr_to_nat(r.substr(i + 1).c_str())
     )
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
@@ -480,9 +480,9 @@ extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getSymbol(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getSymbol().c_str()));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_getId(lean_obj_arg t)
@@ -502,14 +502,14 @@ extern "C" uint8_t term_isSkolem(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getSkolemId(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok_u8(static_cast<int32_t>(term_unbox(t)->getSkolemId()));
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_getSkolemIndices(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   std::vector<Term> args = term_unbox(t)->getSkolemIndices();
   lean_object* as = lean_mk_empty_array();
   for (const Term& arg : args)
@@ -517,7 +517,7 @@ extern "C" lean_obj_res term_getSkolemIndices(lean_obj_arg t)
     as = lean_array_push(as, term_box(new Term(arg)));
   }
   return except_ok(lean_box(0), as);
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res term_get(lean_obj_arg t, lean_obj_arg i)
@@ -669,20 +669,20 @@ extern "C" lean_obj_arg termManager_getStringSort(lean_obj_arg tm)
 
 extern "C" lean_obj_arg termManager_mkArraySort(lean_obj_arg tm, lean_obj_arg idx, lean_obj_arg elm)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     sort_box(new Sort(mut_tm_unbox(tm)->mkArraySort(*sort_unbox(idx), *sort_unbox(elm))))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_arg termManager_mkBitVectorSort(lean_obj_arg tm, uint32_t size)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     sort_box(new Sort(mut_tm_unbox(tm)->mkBitVectorSort(size)))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_arg termManager_mkFloatingPointSort(
@@ -691,11 +691,11 @@ extern "C" lean_obj_arg termManager_mkFloatingPointSort(
   uint32_t sig
 )
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     sort_box(new Sort(mut_tm_unbox(tm)->mkFloatingPointSort(exp, sig)))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_arg termManager_mkFunctionSort(
@@ -704,7 +704,7 @@ extern "C" lean_obj_arg termManager_mkFunctionSort(
   lean_obj_arg codomain
 )
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   std::vector<Sort> cvc5Sorts;
   for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
   {
@@ -714,7 +714,7 @@ extern "C" lean_obj_arg termManager_mkFunctionSort(
   return except_ok(lean_box(0),
     sort_box(new Sort(mut_tm_unbox(tm)->mkFunctionSort(cvc5Sorts, *sort_unbox(codomain))))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
@@ -725,18 +725,18 @@ extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
 extern "C" lean_obj_res termManager_mkIntegerFromString(lean_obj_arg tm,
                                                         lean_obj_arg val)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
     term_box(new Term(mut_tm_unbox(tm)->mkInteger(lean_string_cstr(val))))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res termManager_mkTerm(lean_obj_arg tm,
                                            uint16_t kind,
                                            lean_obj_arg children)
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
   std::vector<Term> cs;
   for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
@@ -747,7 +747,7 @@ extern "C" lean_obj_res termManager_mkTerm(lean_obj_arg tm,
   return except_ok(lean_box(0),
     term_box(new Term(mut_tm_unbox(tm)->mkTerm(k, cs)))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res termManager_mkTermOfOp(
@@ -756,7 +756,7 @@ extern "C" lean_obj_res termManager_mkTermOfOp(
   lean_obj_arg children
 )
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   std::vector<Term> cs;
   for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
   {
@@ -766,7 +766,7 @@ extern "C" lean_obj_res termManager_mkTermOfOp(
   return except_ok(lean_box(0),
     term_box(new Term(mut_tm_unbox(tm)->mkTerm(*op_unbox(op), cs)))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res termManager_mkConst(
@@ -784,7 +784,7 @@ extern "C" lean_obj_res termManager_mkOpOfIndices(
   lean_obj_arg args
 )
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
   std::vector<uint32_t> indices;
   for (size_t i = 0, n = lean_array_size(args); i < n; ++i)
@@ -796,7 +796,7 @@ extern "C" lean_obj_res termManager_mkOpOfIndices(
   return except_ok(lean_box(0),
     op_box(new Op(mut_tm_unbox(tm)->mkOp(k, indices)))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res termManager_mkOpOfString(
@@ -805,12 +805,12 @@ extern "C" lean_obj_res termManager_mkOpOfString(
   lean_obj_arg arg
 )
 {
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
   return except_ok(lean_box(0),
     op_box(new Op(mut_tm_unbox(tm)->mkOp(k, lean_string_cstr(arg))))
   );
-  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 static void solver_finalize(void* obj) { delete static_cast<Solver*>(obj); }
@@ -845,13 +845,13 @@ extern "C" lean_obj_res solver_new(lean_obj_arg tm)
 extern "C" lean_obj_res solver_getVersion(lean_obj_arg inst,
                                           lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   return solver_val(
     lean_box(0), inst, lean_box(0),
     lean_mk_string(solver_unbox(solver)->getVersion().c_str()),
     solver
   );
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_setOption(lean_obj_arg inst,
@@ -859,37 +859,37 @@ extern "C" lean_obj_res solver_setOption(lean_obj_arg inst,
                                          lean_object* value,
                                          lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   solver_unbox(solver)->setOption(lean_string_cstr(option),
                                   lean_string_cstr(value));
   return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_assertFormula(lean_obj_arg inst,
                                              lean_object* term,
                                              lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   solver_unbox(solver)->assertFormula(*term_unbox(term));
   return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_checkSat(lean_obj_arg inst, lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   return solver_val(
     lean_box(0), inst, lean_box(0),
     result_box(new Result(solver_unbox(solver)->checkSat())),
     solver
   );
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_getProof(lean_obj_arg inst, lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   std::vector<Proof> proofs = solver_unbox(solver)->getProof();
   lean_object* ps = lean_mk_empty_array();
   for (const Proof& proof : proofs)
@@ -897,27 +897,27 @@ extern "C" lean_obj_res solver_getProof(lean_obj_arg inst, lean_obj_arg solver)
     ps = lean_array_push(ps, proof_box(new Proof(proof)));
   }
   return solver_val(lean_box(0), inst, lean_box(0), ps, solver);
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_proofToString(lean_obj_arg inst,
                                              lean_obj_arg proof,
                                              lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   return solver_val(
     lean_box(0), inst, lean_box(0),
     lean_mk_string(solver_unbox(solver)->proofToString(*proof_unbox(proof)).c_str()),
     solver
   );
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
 extern "C" lean_obj_res solver_parse(lean_obj_arg inst,
                                      lean_obj_arg query,
                                      lean_obj_arg solver)
 {
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
   Solver* slv = solver_unbox(solver);
   // construct an input parser associated the solver above
   parser::InputParser parser(slv);
@@ -940,5 +940,5 @@ extern "C" lean_obj_res solver_parse(lean_obj_arg inst,
     cmd.invoke(slv, sm, out);
   }
   return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -223,6 +223,11 @@ extern "C" uint64_t sort_hash(lean_obj_arg s)
   return std::hash<Sort>()(*sort_unbox(s));
 }
 
+extern "C" uint8_t sort_isFunction(lean_obj_arg s)
+{
+  return bool_box(sort_unbox(s)->isFunction());
+}
+
 extern "C" lean_obj_res sort_getFunctionDomainSorts(lean_obj_arg s)
 {
   CVC5_TRY_CATCH_EXCEPT(
@@ -404,9 +409,16 @@ extern "C" uint16_t term_getKind(lean_obj_arg t)
   return static_cast<int32_t>(term_unbox(t)->getKind()) + 2;
 }
 
+extern "C" uint8_t term_hasOp(lean_obj_arg t)
+{
+  return bool_box(term_unbox(t)->hasOp());
+}
+
 extern "C" lean_obj_arg term_getOp(lean_obj_arg t)
 {
-  return op_box(new Op(term_unbox(t)->getOp()));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), op_box(new Op(term_unbox(t)->getOp())));
+  )
 }
 
 extern "C" lean_obj_arg term_getSort(lean_obj_arg t)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -32,9 +32,9 @@ extern "C" lean_obj_res except_err(
 //
 // Runs `code`, `return`s an `Except Error α` error on exceptions.
 
-#define CVC5_TRY_CATCH_EXCEPT(code) \
-  try { \
-    code \
+#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN() \
+  try {
+#define CVC5_LEAN_API_TRY_CATCH_EXCEPT_END() \
   } catch (CVC5ApiException& e) { \
     return except_err(lean_box(0), lean_mk_string(e.what())); \
   } catch (char const* e) { \
@@ -230,33 +230,33 @@ extern "C" uint8_t sort_isFunction(lean_obj_arg s)
 
 extern "C" lean_obj_res sort_getFunctionDomainSorts(lean_obj_arg s)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    std::vector<Sort> domains = sort_unbox(s)->getFunctionDomainSorts();
-    lean_object* ds = lean_mk_empty_array();
-    for (const Sort& domain : domains)
-    {
-      ds = lean_array_push(ds, sort_box(new Sort(domain)));
-    }
-    return except_ok(lean_box(0), ds);
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  std::vector<Sort> domains = sort_unbox(s)->getFunctionDomainSorts();
+  lean_object* ds = lean_mk_empty_array();
+  for (const Sort& domain : domains)
+  {
+    ds = lean_array_push(ds, sort_box(new Sort(domain)));
+  }
+  return except_ok(lean_box(0), ds);
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res sort_getFunctionCodomainSort(lean_obj_arg s)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      sort_box(new Sort(sort_unbox(s)->getFunctionCodomainSort()))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    sort_box(new Sort(sort_unbox(s)->getFunctionCodomainSort()))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res sort_getSymbol(lean_obj_arg s)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      lean_mk_string(sort_unbox(s)->getSymbol().c_str())
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    lean_mk_string(sort_unbox(s)->getSymbol().c_str())
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" uint8_t sort_isInteger(lean_obj_arg s)
@@ -266,11 +266,11 @@ extern "C" uint8_t sort_isInteger(lean_obj_arg s)
 
 extern "C" lean_obj_res sort_getBitVectorSize(lean_obj_arg s)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok_u32(
-      static_cast<int32_t>(sort_unbox(s)->getBitVectorSize())
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok_u32(
+    static_cast<int32_t>(sort_unbox(s)->getBitVectorSize())
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res sort_toString(lean_obj_arg s)
@@ -380,23 +380,23 @@ extern "C" uint8_t term_isNull(lean_obj_arg t)
 
 extern "C" lean_obj_res term_not(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), term_box(new Term(term_unbox(t)->notTerm())));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), term_box(new Term(term_unbox(t)->notTerm())));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_and(lean_obj_arg t1, lean_obj_arg t2)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->andTerm(*term_unbox(t2)))));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->andTerm(*term_unbox(t2)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_or(lean_obj_arg t1, lean_obj_arg t2)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->orTerm(*term_unbox(t2)))));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->orTerm(*term_unbox(t2)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_toString(lean_obj_arg t)
@@ -416,9 +416,9 @@ extern "C" uint8_t term_hasOp(lean_obj_arg t)
 
 extern "C" lean_obj_arg term_getOp(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), op_box(new Op(term_unbox(t)->getOp())));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), op_box(new Op(term_unbox(t)->getOp())));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_arg term_getSort(lean_obj_arg t)
@@ -438,39 +438,39 @@ extern "C" uint64_t term_hash(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getBooleanValue(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok_bool(bool_box(term_unbox(t)->getBooleanValue()));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok_bool(bool_box(term_unbox(t)->getBooleanValue()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_getBitVectorValue(lean_obj_arg t, uint32_t base)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getBitVectorValue(base).c_str()));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getBitVectorValue(base).c_str()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_getIntegerValue(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), lean_cstr_to_int(term_unbox(t)->getIntegerValue().c_str()));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), lean_cstr_to_int(term_unbox(t)->getIntegerValue().c_str()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res l_Lean_mkRat(lean_obj_arg num, lean_obj_arg den);
 
 extern "C" lean_obj_res term_getRationalValue(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    std::string r = term_unbox(t)->getRealValue();
-    size_t i = r.find('/');
-    return except_ok(lean_box(0),
-      l_Lean_mkRat(
-        lean_cstr_to_int(r.substr(0, i).c_str()),
-        lean_cstr_to_nat(r.substr(i + 1).c_str())
-      )
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  std::string r = term_unbox(t)->getRealValue();
+  size_t i = r.find('/');
+  return except_ok(lean_box(0),
+    l_Lean_mkRat(
+      lean_cstr_to_int(r.substr(0, i).c_str()),
+      lean_cstr_to_nat(r.substr(i + 1).c_str())
+    )
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
@@ -480,9 +480,9 @@ extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getSymbol(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getSymbol().c_str()));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getSymbol().c_str()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_getId(lean_obj_arg t)
@@ -502,22 +502,22 @@ extern "C" uint8_t term_isSkolem(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getSkolemId(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok_u8(static_cast<int32_t>(term_unbox(t)->getSkolemId()));
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok_u8(static_cast<int32_t>(term_unbox(t)->getSkolemId()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_getSkolemIndices(lean_obj_arg t)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    std::vector<Term> args = term_unbox(t)->getSkolemIndices();
-    lean_object* as = lean_mk_empty_array();
-    for (const Term& arg : args)
-    {
-      as = lean_array_push(as, term_box(new Term(arg)));
-    }
-    return except_ok(lean_box(0), as);
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  std::vector<Term> args = term_unbox(t)->getSkolemIndices();
+  lean_object* as = lean_mk_empty_array();
+  for (const Term& arg : args)
+  {
+    as = lean_array_push(as, term_box(new Term(arg)));
+  }
+  return except_ok(lean_box(0), as);
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res term_get(lean_obj_arg t, lean_obj_arg i)
@@ -669,20 +669,20 @@ extern "C" lean_obj_arg termManager_getStringSort(lean_obj_arg tm)
 
 extern "C" lean_obj_arg termManager_mkArraySort(lean_obj_arg tm, lean_obj_arg idx, lean_obj_arg elm)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      sort_box(new Sort(mut_tm_unbox(tm)->mkArraySort(*sort_unbox(idx), *sort_unbox(elm))))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    sort_box(new Sort(mut_tm_unbox(tm)->mkArraySort(*sort_unbox(idx), *sort_unbox(elm))))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_arg termManager_mkBitVectorSort(lean_obj_arg tm, uint32_t size)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      sort_box(new Sort(mut_tm_unbox(tm)->mkBitVectorSort(size)))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    sort_box(new Sort(mut_tm_unbox(tm)->mkBitVectorSort(size)))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_arg termManager_mkFloatingPointSort(
@@ -691,11 +691,11 @@ extern "C" lean_obj_arg termManager_mkFloatingPointSort(
   uint32_t sig
 )
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      sort_box(new Sort(mut_tm_unbox(tm)->mkFloatingPointSort(exp, sig)))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    sort_box(new Sort(mut_tm_unbox(tm)->mkFloatingPointSort(exp, sig)))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_arg termManager_mkFunctionSort(
@@ -704,17 +704,17 @@ extern "C" lean_obj_arg termManager_mkFunctionSort(
   lean_obj_arg codomain
 )
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    std::vector<Sort> cvc5Sorts;
-    for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
-    {
-      cvc5Sorts.push_back(*sort_unbox(
-          lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
-    }
-    return except_ok(lean_box(0),
-      sort_box(new Sort(mut_tm_unbox(tm)->mkFunctionSort(cvc5Sorts, *sort_unbox(codomain))))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  std::vector<Sort> cvc5Sorts;
+  for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
+  {
+    cvc5Sorts.push_back(*sort_unbox(
+        lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
+  }
+  return except_ok(lean_box(0),
+    sort_box(new Sort(mut_tm_unbox(tm)->mkFunctionSort(cvc5Sorts, *sort_unbox(codomain))))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
@@ -725,29 +725,29 @@ extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
 extern "C" lean_obj_res termManager_mkIntegerFromString(lean_obj_arg tm,
                                                         lean_obj_arg val)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    return except_ok(lean_box(0),
-      term_box(new Term(mut_tm_unbox(tm)->mkInteger(lean_string_cstr(val))))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  return except_ok(lean_box(0),
+    term_box(new Term(mut_tm_unbox(tm)->mkInteger(lean_string_cstr(val))))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res termManager_mkTerm(lean_obj_arg tm,
                                            uint16_t kind,
                                            lean_obj_arg children)
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-    std::vector<Term> cs;
-    for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
-    {
-      cs.push_back(*term_unbox(
-          lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
-    }
-    return except_ok(lean_box(0),
-      term_box(new Term(mut_tm_unbox(tm)->mkTerm(k, cs)))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+  std::vector<Term> cs;
+  for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
+  {
+    cs.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
+  }
+  return except_ok(lean_box(0),
+    term_box(new Term(mut_tm_unbox(tm)->mkTerm(k, cs)))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res termManager_mkTermOfOp(
@@ -756,17 +756,17 @@ extern "C" lean_obj_res termManager_mkTermOfOp(
   lean_obj_arg children
 )
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    std::vector<Term> cs;
-    for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
-    {
-      cs.push_back(*term_unbox(
-          lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
-    }
-    return except_ok(lean_box(0),
-      term_box(new Term(mut_tm_unbox(tm)->mkTerm(*op_unbox(op), cs)))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  std::vector<Term> cs;
+  for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
+  {
+    cs.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
+  }
+  return except_ok(lean_box(0),
+    term_box(new Term(mut_tm_unbox(tm)->mkTerm(*op_unbox(op), cs)))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res termManager_mkConst(
@@ -784,19 +784,19 @@ extern "C" lean_obj_res termManager_mkOpOfIndices(
   lean_obj_arg args
 )
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-    std::vector<uint32_t> indices;
-    for (size_t i = 0, n = lean_array_size(args); i < n; ++i)
-    {
-      indices.push_back(
-        lean_uint32_of_nat(lean_array_get(0, args, lean_usize_to_nat(i)))
-      );
-    }
-    return except_ok(lean_box(0),
-      op_box(new Op(mut_tm_unbox(tm)->mkOp(k, indices)))
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+  std::vector<uint32_t> indices;
+  for (size_t i = 0, n = lean_array_size(args); i < n; ++i)
+  {
+    indices.push_back(
+      lean_uint32_of_nat(lean_array_get(0, args, lean_usize_to_nat(i)))
     );
-  )
+  }
+  return except_ok(lean_box(0),
+    op_box(new Op(mut_tm_unbox(tm)->mkOp(k, indices)))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 extern "C" lean_obj_res termManager_mkOpOfString(
@@ -805,12 +805,12 @@ extern "C" lean_obj_res termManager_mkOpOfString(
   lean_obj_arg arg
 )
 {
-  CVC5_TRY_CATCH_EXCEPT(
-    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-    return except_ok(lean_box(0),
-      op_box(new Op(mut_tm_unbox(tm)->mkOp(k, lean_string_cstr(arg))))
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN()
+  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+  return except_ok(lean_box(0),
+    op_box(new Op(mut_tm_unbox(tm)->mkOp(k, lean_string_cstr(arg))))
+  );
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END()
 }
 
 static void solver_finalize(void* obj) { delete static_cast<Solver*>(obj); }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -4,6 +4,74 @@
 
 using namespace cvc5;
 
+// ## `Extern Error α` constructors
+
+extern "C" lean_obj_res except_ok(
+  lean_obj_arg alpha,
+  lean_obj_arg val
+);
+
+extern "C" lean_obj_res except_ok_bool(
+  uint8_t val
+);
+
+extern "C" lean_obj_res except_ok_u32(
+  uint32_t val
+);
+
+extern "C" lean_obj_res except_ok_u8(
+  uint8_t val
+);
+
+extern "C" lean_obj_res except_err(
+  lean_obj_arg alpha,
+  lean_obj_arg msg
+);
+
+// ## Exception-catching macro for `Except`
+//
+// Runs `code`, `return`s an `Except Error α` error on exceptions.
+
+#define CVC5_TRY_CATCH_EXCEPT(code) \
+  try { \
+    code \
+  } catch (CVC5ApiException& e) { \
+    return except_err(lean_box(0), lean_mk_string(e.what())); \
+  } catch (char const* e) { \
+    return except_err(lean_box(0), lean_mk_string(e)); \
+  } catch (...) { \
+    return except_err( \
+      lean_box(0), \
+      lean_mk_string("cvc5's term manager raised an unexpected exception") \
+    ); \
+  }
+
+// ## Exception-catching macro for `SolverT`
+//
+// Runs `code`, `return`s an `Error` for `SolverT` on exceptions.
+//
+// - `inst`: monad instance.
+// - `solver`: solver state value.
+// - `code`: the code to run and catch exceptions for.
+
+#define CVC5_TRY_CATCH_SOLVER(inst, solver, code) \
+  try { \
+    code \
+  } catch (CVC5ApiException& e) { \
+    return solver_errOfString( \
+      lean_box(0), inst, lean_box(0), lean_mk_string(e.what()), solver \
+    ); \
+  } catch (char const* e) { \
+    return solver_errOfString( \
+      lean_box(0), inst, lean_box(0), lean_mk_string(e), solver \
+    ); \
+  } catch (...) { \
+    return solver_errOfString( \
+      lean_box(0), inst, lean_box(0), \
+      lean_mk_string("cvc5 raised an unexpected exception"), solver \
+    ); \
+  }
+
 inline lean_obj_res mk_unit_unit() { return lean_box(0); }
 
 inline uint8_t mk_bool_false() { return 0; }
@@ -131,23 +199,33 @@ extern "C" uint64_t sort_hash(lean_obj_arg s)
 
 extern "C" lean_obj_res sort_getFunctionDomainSorts(lean_obj_arg s)
 {
-  std::vector<Sort> domains = sort_unbox(s)->getFunctionDomainSorts();
-  lean_object* ds = lean_mk_empty_array();
-  for (const Sort& domain : domains)
-  {
-    ds = lean_array_push(ds, sort_box(new Sort(domain)));
-  }
-  return ds;
+  CVC5_TRY_CATCH_EXCEPT(
+    std::vector<Sort> domains = sort_unbox(s)->getFunctionDomainSorts();
+    lean_object* ds = lean_mk_empty_array();
+    for (const Sort& domain : domains)
+    {
+      ds = lean_array_push(ds, sort_box(new Sort(domain)));
+    }
+    return except_ok(lean_box(0), ds);
+  )
 }
 
 extern "C" lean_obj_res sort_getFunctionCodomainSort(lean_obj_arg s)
 {
-  return sort_box(new Sort(sort_unbox(s)->getFunctionCodomainSort()));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      sort_box(new Sort(sort_unbox(s)->getFunctionCodomainSort()))
+    );
+  )
 }
 
 extern "C" lean_obj_res sort_getSymbol(lean_obj_arg s)
 {
-  return lean_mk_string(sort_unbox(s)->getSymbol().c_str());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      lean_mk_string(sort_unbox(s)->getSymbol().c_str())
+    );
+  )
 }
 
 extern "C" uint8_t sort_isInteger(lean_obj_arg s)
@@ -155,9 +233,13 @@ extern "C" uint8_t sort_isInteger(lean_obj_arg s)
   return bool_box(sort_unbox(s)->isInteger());
 }
 
-extern "C" uint32_t sort_getBitVectorSize(lean_obj_arg s)
+extern "C" lean_obj_res sort_getBitVectorSize(lean_obj_arg s)
 {
-  return static_cast<int32_t>(sort_unbox(s)->getBitVectorSize());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok_u32(
+      static_cast<int32_t>(sort_unbox(s)->getBitVectorSize())
+    );
+  )
 }
 
 extern "C" lean_obj_res sort_toString(lean_obj_arg s)
@@ -267,17 +349,23 @@ extern "C" uint8_t term_isNull(lean_obj_arg t)
 
 extern "C" lean_obj_res term_not(lean_obj_arg t)
 {
-  return term_box(new Term(term_unbox(t)->notTerm()));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), term_box(new Term(term_unbox(t)->notTerm())));
+  )
 }
 
 extern "C" lean_obj_res term_and(lean_obj_arg t1, lean_obj_arg t2)
 {
-  return term_box(new Term(term_unbox(t1)->andTerm(*term_unbox(t2))));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->andTerm(*term_unbox(t2)))));
+  )
 }
 
 extern "C" lean_obj_res term_or(lean_obj_arg t1, lean_obj_arg t2)
 {
-  return term_box(new Term(term_unbox(t1)->orTerm(*term_unbox(t2))));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), term_box(new Term(term_unbox(t1)->orTerm(*term_unbox(t2)))));
+  )
 }
 
 extern "C" lean_obj_res term_toString(lean_obj_arg t)
@@ -310,29 +398,41 @@ extern "C" uint64_t term_hash(lean_obj_arg t)
   return std::hash<Term>()(*term_unbox(t));
 }
 
-extern "C" uint8_t term_getBooleanValue(lean_obj_arg t)
+extern "C" lean_obj_res term_getBooleanValue(lean_obj_arg t)
 {
-  return bool_box(term_unbox(t)->getBooleanValue());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok_bool(bool_box(term_unbox(t)->getBooleanValue()));
+  )
 }
 
 extern "C" lean_obj_res term_getBitVectorValue(lean_obj_arg t, uint32_t base)
 {
-  return lean_mk_string(term_unbox(t)->getBitVectorValue(base).c_str());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getBitVectorValue(base).c_str()));
+  )
 }
 
 extern "C" lean_obj_res term_getIntegerValue(lean_obj_arg t)
 {
-  return lean_cstr_to_int(term_unbox(t)->getIntegerValue().c_str());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), lean_cstr_to_int(term_unbox(t)->getIntegerValue().c_str()));
+  )
 }
 
 extern "C" lean_obj_res l_Lean_mkRat(lean_obj_arg num, lean_obj_arg den);
 
 extern "C" lean_obj_res term_getRationalValue(lean_obj_arg t)
 {
-  std::string r = term_unbox(t)->getRealValue();
-  size_t i = r.find('/');
-  return l_Lean_mkRat(lean_cstr_to_int(r.substr(0, i).c_str()),
-                      lean_cstr_to_nat(r.substr(i + 1).c_str()));
+  CVC5_TRY_CATCH_EXCEPT(
+    std::string r = term_unbox(t)->getRealValue();
+    size_t i = r.find('/');
+    return except_ok(lean_box(0),
+      l_Lean_mkRat(
+        lean_cstr_to_int(r.substr(0, i).c_str()),
+        lean_cstr_to_nat(r.substr(i + 1).c_str())
+      )
+    );
+  )
 }
 
 extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
@@ -342,7 +442,9 @@ extern "C" uint8_t term_hasSymbol(lean_obj_arg t)
 
 extern "C" lean_obj_res term_getSymbol(lean_obj_arg t)
 {
-  return lean_mk_string(term_unbox(t)->getSymbol().c_str());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0), lean_mk_string(term_unbox(t)->getSymbol().c_str()));
+  )
 }
 
 extern "C" lean_obj_res term_getId(lean_obj_arg t)
@@ -360,20 +462,24 @@ extern "C" uint8_t term_isSkolem(lean_obj_arg t)
   return bool_box(term_unbox(t)->isSkolem());
 }
 
-extern "C" uint8_t term_getSkolemId(lean_obj_arg t)
+extern "C" lean_obj_res term_getSkolemId(lean_obj_arg t)
 {
-  return static_cast<int32_t>(term_unbox(t)->getSkolemId());
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok_u8(static_cast<int32_t>(term_unbox(t)->getSkolemId()));
+  )
 }
 
 extern "C" lean_obj_res term_getSkolemIndices(lean_obj_arg t)
 {
-  std::vector<Term> args = term_unbox(t)->getSkolemIndices();
-  lean_object* as = lean_mk_empty_array();
-  for (const Term& arg : args)
-  {
-    as = lean_array_push(as, term_box(new Term(arg)));
-  }
-  return as;
+  CVC5_TRY_CATCH_EXCEPT(
+    std::vector<Term> args = term_unbox(t)->getSkolemIndices();
+    lean_object* as = lean_mk_empty_array();
+    for (const Term& arg : args)
+    {
+      as = lean_array_push(as, term_box(new Term(arg)));
+    }
+    return except_ok(lean_box(0), as);
+  )
 }
 
 extern "C" lean_obj_res term_get(lean_obj_arg t, lean_obj_arg i)
@@ -525,12 +631,20 @@ extern "C" lean_obj_arg termManager_getStringSort(lean_obj_arg tm)
 
 extern "C" lean_obj_arg termManager_mkArraySort(lean_obj_arg tm, lean_obj_arg idx, lean_obj_arg elm)
 {
-  return sort_box(new Sort(mut_tm_unbox(tm)->mkArraySort(*sort_unbox(idx), *sort_unbox(elm))));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      sort_box(new Sort(mut_tm_unbox(tm)->mkArraySort(*sort_unbox(idx), *sort_unbox(elm))))
+    );
+  )
 }
 
 extern "C" lean_obj_arg termManager_mkBitVectorSort(lean_obj_arg tm, uint32_t size)
 {
-  return sort_box(new Sort(mut_tm_unbox(tm)->mkBitVectorSort(size)));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      sort_box(new Sort(mut_tm_unbox(tm)->mkBitVectorSort(size)))
+    );
+  )
 }
 
 extern "C" lean_obj_arg termManager_mkFloatingPointSort(
@@ -539,7 +653,11 @@ extern "C" lean_obj_arg termManager_mkFloatingPointSort(
   uint32_t sig
 )
 {
-  return sort_box(new Sort(mut_tm_unbox(tm)->mkFloatingPointSort(exp, sig)));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      sort_box(new Sort(mut_tm_unbox(tm)->mkFloatingPointSort(exp, sig)))
+    );
+  )
 }
 
 extern "C" lean_obj_arg termManager_mkFunctionSort(
@@ -548,13 +666,17 @@ extern "C" lean_obj_arg termManager_mkFunctionSort(
   lean_obj_arg codomain
 )
 {
-  std::vector<Sort> cvc5Sorts;
-  for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
-  {
-    cvc5Sorts.push_back(*sort_unbox(
-        lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
-  }
-  return sort_box(new Sort(mut_tm_unbox(tm)->mkFunctionSort(cvc5Sorts, *sort_unbox(codomain))));
+  CVC5_TRY_CATCH_EXCEPT(
+    std::vector<Sort> cvc5Sorts;
+    for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
+    {
+      cvc5Sorts.push_back(*sort_unbox(
+          lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
+    }
+    return except_ok(lean_box(0),
+      sort_box(new Sort(mut_tm_unbox(tm)->mkFunctionSort(cvc5Sorts, *sort_unbox(codomain))))
+    );
+  )
 }
 
 extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
@@ -565,21 +687,29 @@ extern "C" lean_obj_res termManager_mkBoolean(lean_obj_arg tm, uint8_t val)
 extern "C" lean_obj_res termManager_mkIntegerFromString(lean_obj_arg tm,
                                                         lean_obj_arg val)
 {
-  return term_box(new Term(mut_tm_unbox(tm)->mkInteger(lean_string_cstr(val))));
+  CVC5_TRY_CATCH_EXCEPT(
+    return except_ok(lean_box(0),
+      term_box(new Term(mut_tm_unbox(tm)->mkInteger(lean_string_cstr(val))))
+    );
+  )
 }
 
 extern "C" lean_obj_res termManager_mkTerm(lean_obj_arg tm,
                                            uint16_t kind,
                                            lean_obj_arg children)
 {
-  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-  std::vector<Term> cs;
-  for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
-  {
-    cs.push_back(*term_unbox(
-        lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
-  }
-  return term_box(new Term(mut_tm_unbox(tm)->mkTerm(k, cs)));
+  CVC5_TRY_CATCH_EXCEPT(
+    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+    std::vector<Term> cs;
+    for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
+    {
+      cs.push_back(*term_unbox(
+          lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
+    }
+    return except_ok(lean_box(0),
+      term_box(new Term(mut_tm_unbox(tm)->mkTerm(k, cs)))
+    );
+  )
 }
 
 extern "C" lean_obj_res termManager_mkTermOfOp(
@@ -588,13 +718,17 @@ extern "C" lean_obj_res termManager_mkTermOfOp(
   lean_obj_arg children
 )
 {
-  std::vector<Term> cs;
-  for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
-  {
-    cs.push_back(*term_unbox(
-        lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
-  }
-  return term_box(new Term(mut_tm_unbox(tm)->mkTerm(*op_unbox(op), cs)));
+  CVC5_TRY_CATCH_EXCEPT(
+    std::vector<Term> cs;
+    for (size_t i = 0, n = lean_array_size(children); i < n; ++i)
+    {
+      cs.push_back(*term_unbox(
+          lean_array_get(term_box(new Term()), children, lean_usize_to_nat(i))));
+    }
+    return except_ok(lean_box(0),
+      term_box(new Term(mut_tm_unbox(tm)->mkTerm(*op_unbox(op), cs)))
+    );
+  )
 }
 
 extern "C" lean_obj_res termManager_mkConst(
@@ -612,15 +746,19 @@ extern "C" lean_obj_res termManager_mkOpOfIndices(
   lean_obj_arg args
 )
 {
-  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-  std::vector<uint32_t> indices;
-  for (size_t i = 0, n = lean_array_size(args); i < n; ++i)
-  {
-    indices.push_back(
-      lean_uint32_of_nat(lean_array_get(0, args, lean_usize_to_nat(i)))
+  CVC5_TRY_CATCH_EXCEPT(
+    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+    std::vector<uint32_t> indices;
+    for (size_t i = 0, n = lean_array_size(args); i < n; ++i)
+    {
+      indices.push_back(
+        lean_uint32_of_nat(lean_array_get(0, args, lean_usize_to_nat(i)))
+      );
+    }
+    return except_ok(lean_box(0),
+      op_box(new Op(mut_tm_unbox(tm)->mkOp(k, indices)))
     );
-  }
-  return op_box(new Op(mut_tm_unbox(tm)->mkOp(k, indices)));
+  )
 }
 
 extern "C" lean_obj_res termManager_mkOpOfString(
@@ -629,8 +767,12 @@ extern "C" lean_obj_res termManager_mkOpOfString(
   lean_obj_arg arg
 )
 {
-  Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
-  return op_box(new Op(mut_tm_unbox(tm)->mkOp(k, lean_string_cstr(arg))));
+  CVC5_TRY_CATCH_EXCEPT(
+    Kind k = static_cast<Kind>(static_cast<int32_t>(kind) - 2);
+    return except_ok(lean_box(0),
+      op_box(new Op(mut_tm_unbox(tm)->mkOp(k, lean_string_cstr(arg))))
+    );
+  )
 }
 
 static void solver_finalize(void* obj) { delete static_cast<Solver*>(obj); }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -80,9 +80,9 @@ extern "C" lean_obj_res solver_errOfString(
 // - `solver`: solver state value.
 // - `code`: the code to run and catch exceptions for.
 
-#define CVC5_TRY_CATCH_SOLVER(inst, solver, code) \
-  try { \
-    code \
+#define CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN() \
+  try {
+#define CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver) \
   } catch (CVC5ApiException& e) { \
     return solver_errOfString( \
       lean_box(0), inst, lean_box(0), lean_mk_string(e.what()), solver \
@@ -845,13 +845,13 @@ extern "C" lean_obj_res solver_new(lean_obj_arg tm)
 extern "C" lean_obj_res solver_getVersion(lean_obj_arg inst,
                                           lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    return solver_val(
-      lean_box(0), inst, lean_box(0),
-      lean_mk_string(solver_unbox(solver)->getVersion().c_str()),
-      solver
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  return solver_val(
+    lean_box(0), inst, lean_box(0),
+    lean_mk_string(solver_unbox(solver)->getVersion().c_str()),
+    solver
+  );
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_setOption(lean_obj_arg inst,
@@ -859,86 +859,86 @@ extern "C" lean_obj_res solver_setOption(lean_obj_arg inst,
                                          lean_object* value,
                                          lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    solver_unbox(solver)->setOption(lean_string_cstr(option),
-                                    lean_string_cstr(value));
-    return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  solver_unbox(solver)->setOption(lean_string_cstr(option),
+                                  lean_string_cstr(value));
+  return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_assertFormula(lean_obj_arg inst,
                                              lean_object* term,
                                              lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    solver_unbox(solver)->assertFormula(*term_unbox(term));
-    return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  solver_unbox(solver)->assertFormula(*term_unbox(term));
+  return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_checkSat(lean_obj_arg inst, lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    return solver_val(
-      lean_box(0), inst, lean_box(0),
-      result_box(new Result(solver_unbox(solver)->checkSat())),
-      solver
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  return solver_val(
+    lean_box(0), inst, lean_box(0),
+    result_box(new Result(solver_unbox(solver)->checkSat())),
+    solver
+  );
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_getProof(lean_obj_arg inst, lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    std::vector<Proof> proofs = solver_unbox(solver)->getProof();
-    lean_object* ps = lean_mk_empty_array();
-    for (const Proof& proof : proofs)
-    {
-      ps = lean_array_push(ps, proof_box(new Proof(proof)));
-    }
-    return solver_val(lean_box(0), inst, lean_box(0), ps, solver);
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  std::vector<Proof> proofs = solver_unbox(solver)->getProof();
+  lean_object* ps = lean_mk_empty_array();
+  for (const Proof& proof : proofs)
+  {
+    ps = lean_array_push(ps, proof_box(new Proof(proof)));
+  }
+  return solver_val(lean_box(0), inst, lean_box(0), ps, solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_proofToString(lean_obj_arg inst,
                                              lean_obj_arg proof,
                                              lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    return solver_val(
-      lean_box(0), inst, lean_box(0),
-      lean_mk_string(solver_unbox(solver)->proofToString(*proof_unbox(proof)).c_str()),
-      solver
-    );
-  )
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  return solver_val(
+    lean_box(0), inst, lean_box(0),
+    lean_mk_string(solver_unbox(solver)->proofToString(*proof_unbox(proof)).c_str()),
+    solver
+  );
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }
 
 extern "C" lean_obj_res solver_parse(lean_obj_arg inst,
                                      lean_obj_arg query,
                                      lean_obj_arg solver)
 {
-  CVC5_TRY_CATCH_SOLVER(inst, solver,
-    Solver* slv = solver_unbox(solver);
-    // construct an input parser associated the solver above
-    parser::InputParser parser(slv);
-    // get the symbol manager of the parser, used when invoking commands below
-    parser::SymbolManager* sm = parser.getSymbolManager();
-    parser.setStringInput(
-        modes::InputLanguage::SMT_LIB_2_6, lean_string_cstr(query), "lean-smt");
-    // parse commands until finished
-    std::stringstream out;
-    parser::Command cmd;
-    while (true)
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN()
+  Solver* slv = solver_unbox(solver);
+  // construct an input parser associated the solver above
+  parser::InputParser parser(slv);
+  // get the symbol manager of the parser, used when invoking commands below
+  parser::SymbolManager* sm = parser.getSymbolManager();
+  parser.setStringInput(
+      modes::InputLanguage::SMT_LIB_2_6, lean_string_cstr(query), "lean-smt");
+  // parse commands until finished
+  std::stringstream out;
+  parser::Command cmd;
+  while (true)
+  {
+    cmd = parser.nextCommand();
+    if (cmd.isNull())
     {
-      cmd = parser.nextCommand();
-      if (cmd.isNull())
-      {
-        break;
-      }
-      // invoke the command on the solver and the symbol manager, print the result
-      // to out
-      cmd.invoke(slv, sm, out);
+      break;
     }
-    return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
-  )
+    // invoke the command on the solver and the symbol manager, print the result
+    // to out
+    cmd.invoke(slv, sm, out);
+  }
+  return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver)
 }


### PR DESCRIPTION
# Error type

`Error` type modified to fit @abdoo8080's specification.

# Exception-handling

> Exception-handling improves user experience significantly, but it is also mandatory if we want to check failures of solver, term, ... functions. This is because C++-level exceptions (seemingly) crash the lean server and there's no way (AFAIK) to (gracefully) check the panic occurred and what the error message was in a test.

Wrap exception-raising C++ calls in a macro that catches errors and turns them into lean `Except Error _`. There are two C++ macros, one for `Except Error _` results, and one for `SolverT _ _` results.

This turns many of the `TermManager`, `Term`, `Sort`... functions that previously produced non-`Except` types to yield `Except Error _` instead. `SolverT` functions are unchanged as they were already in a error monad.

# Documentation

(Virtually) all functions in `Solver.lean` have been documented. In particular function lifted from cvc5 are all documented with the documentation of the associated C++ function (sometimes slightly altered for lean).

# DRY extern-def macro improvements

The `extern!` macro is now more coherent (to me at least) and more expressive than the previous version. See documentation (and uses) for details.
`extern_def?`, `extern_def!`, `extern_def!?`, and `extern_def?!` have all been removed.

# Additional functions

This PR also adds `Sort.isFunction`, `Term.hasOp`.