### PR TITLE
Use explicitly clang instead of cc

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -109,7 +109,7 @@ target ffi.o pkg : FilePath := do
       "-I", (pkg.buildDir / s!"cvc5-{cvc5.target}" / "include").toString,
       "-fPIC"
     ]
-    buildO oFile srcJob flags
+    buildO (compiler := "clang") oFile srcJob flags
 
 def libs := #["cadical", "cvc5", "cvc5parser", "gmp", "gmpxx", "picpoly", "picpolyxx"]
 


### PR DESCRIPTION
If you don't pass the `compiler` argument to `buildO` it defaults to `cc`. This only works if `cc` is set to `clang`, since the option `-stdlib=libc++` does not exist for `gcc`, only for `clang`. This PR makes it explicit that we want `clang` and not `gcc`.