### PR TITLE
bump to 4.16, add `simplify`, `setLogic`, and `resetAssertions`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
         auto-config: false
         use-github-cache: false
     - name: Download cvc5 Release
-      run: lake run downloadRelease
+      run: lake run init
     - name: Build and Test lean-cvc5
       uses: leanprover/lean-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -10,9 +10,6 @@ with cvc5 by calling its functions and accessing its API.
 ## Limitations
 
 - Minimal interface to the cvc5 solver (contributions are welcome!)
-- 
-- Currently only works with Linux (x86_64) and macOS (AArch64 and x86_64) (support for Windows and
-  other architectures is planned for future releases)
 
 ## Getting Started
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ require smt from git "https://github.com/abdoo8080/lean-cvc5.git" @ "main"
 Build this library by running the `init` script before `lake`-building:
 
 ```text
-lake script run init
+lake run init
 [...]
 lake build
 [...]

--- a/README.md
+++ b/README.md
@@ -2,26 +2,46 @@
 
 ## Overview
 
-The Lean cvc5 is a Foreign Function Interface (FFI) library that provides a minimal interface to the cvc5 solver in Lean. It was designed to support the needs of the [lean-smt](https://github.com/ufmg-smite/lean-smt) tactic. The FFI allows Lean programs to interact with cvc5 by calling its functions and accessing its API.
+The Lean cvc5 is a Foreign Function Interface (FFI) library that provides a minimal interface to the
+cvc5 solver in Lean. It was designed to support the needs of the
+[lean-smt] tactic. The FFI allows Lean programs to interact
+with cvc5 by calling its functions and accessing its API.
 
 ## Limitations
 
 - Minimal interface to the cvc5 solver (contributions are welcome!)
-- Currently only works with Linux (x86_64) and macOS (AArch64 and x86_64) (support for Windows and other architectures is planned for future releases)
+- 
+- Currently only works with Linux (x86_64) and macOS (AArch64 and x86_64) (support for Windows and
+  other architectures is planned for future releases)
 
 ## Getting Started
 
-To use the cvc5 FFI in your project, add the following line to your list of dependencies in `lakefile.lean`:
+To use the cvc5 FFI in your project, add the following line to your list of dependencies in
+`lakefile.lean`:
 
 ```lean
 require smt from git "https://github.com/abdoo8080/lean-cvc5.git" @ "main"
 ```
 
+## Building
+
+Build this library by running the `init` script before `lake`-building:
+
+```text
+lake script run init
+[...]
+lake build
+[...]
+```
+
 ## Contributing
 
-Contributions to the Lean cvc5 FFI project are welcome! If you would like to contribute, please follow these guidelines:
+Contributions to the Lean cvc5 FFI project are welcome! If you would like to contribute, please
+follow these guidelines:
 
 1. Fork the repository
 2. Create a new branch for your feature or bug fix
     <!-- 3. Make your changes and ensure all tests pass -->
 3. Submit a pull request with a clear description of your changes
+
+[lean-smt]: https://github.com/ufmg-smite/lean-smt

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -575,6 +575,26 @@ extern_def getVersion : SolverT m String
 -/
 extern_def setOption (option value : String) : SolverT m Unit
 
+/-- Remove all assertions. -/
+extern_def resetAssertions : SolverT m Unit
+
+/-- Set logic.
+
+- `logic`: The logic to set.
+-/
+extern_def setLogic : (logic : String) → SolverT m Unit
+
+/-- Simplify a term or formula based on rewriting and (optionally) applying substitutions for
+solved variables.
+
+If `applySubs` is true, then for example, if `(= x 0)` was asserted to this solver, this function
+may replace occurrences of `x` with `0`.
+
+- `t` The term to simplify.
+- `applySubs` True to apply substitutions for solved variables.
+-/
+extern_def simplify : (term : Term) → (applySubs : Bool := false) → SolverT m Term
+
 /--
 Declare n-ary function symbol.
 

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -849,6 +849,42 @@ extern "C" lean_obj_res solver_setOption(lean_obj_arg inst,
   CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
 }
 
+extern "C" lean_obj_res solver_resetAssertions(
+  lean_obj_arg inst,
+  lean_obj_arg solver
+) {
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
+  solver_unbox(solver)->resetAssertions();
+  return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
+}
+
+extern "C" lean_obj_res solver_setLogic(
+  lean_obj_arg inst,
+  lean_object* logic,
+  lean_obj_arg solver
+) {
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
+  solver_unbox(solver)->setLogic(lean_string_cstr(logic));
+  return solver_val(lean_box(0), inst, lean_box(0), mk_unit_unit(), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
+}
+
+extern "C" lean_obj_res solver_simplify(
+  lean_obj_arg inst,
+  lean_obj_arg term,
+  lean_obj_arg applySubs,
+  lean_obj_arg solver
+) {
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
+  Term value = solver_unbox(solver)->simplify(
+    *term_unbox(term),
+    bool_unbox(lean_unbox(applySubs))
+  );
+  return solver_val(lean_box(0), inst, lean_box(0), term_box(new Term(value)), solver);
+  CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);
+}
+
 extern "C" lean_obj_res solver_declareFun(lean_obj_arg inst,
                                           lean_obj_arg symbol,
                                           lean_obj_arg sorts,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -56,10 +56,12 @@ def generateEnums (cppDir : FilePath) (pkg : NPackage _package.name) : IO Unit :
 ```\
     "
 
-/--
-Download cvc5 release and update enumerations.
+/-- Initialization script.
+
+- download cvc5 release;
+- generate lean-enumerations.
 -/
-script downloadRelease do
+script init do
   let ws ← getWorkspace
   let args := ws.lakeArgs?.getD #[]
   let v := Verbosity.normal
@@ -93,9 +95,9 @@ def Lake.compileStaticLib'
 
 /-- Build a static library from object file jobs using the `ar` packaged with Lean. -/
 def Lake.buildStaticLib'
-  (libFile : FilePath) (oFileJobs : Array (BuildJob FilePath))
-: SpawnM (BuildJob FilePath) :=
-  buildFileAfterDepArray libFile oFileJobs fun oFiles => do
+  (libFile : FilePath) (oFileJobs : Array (Job FilePath))
+: SpawnM (Job FilePath) :=
+  buildFileAfterDep libFile (.collectArray oFileJobs) fun oFiles => do
     compileStaticLib' libFile oFiles (← getLeanAr)
 
 target ffi.o pkg : FilePath := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -58,8 +58,8 @@ def generateEnums (cppDir : FilePath) (pkg : NPackage _package.name) : IO Unit :
 
 /-- Initialization script.
 
-- download cvc5 release;
-- generate lean-enumerations.
+- download cvc5 release files;
+- generate/update lean-enumerations.
 -/
 script init do
   let ws ← getWorkspace

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.15.0
+leanprover/lean4:v4.16.0


### PR DESCRIPTION
- bump to 4.16.0
- `lake run downloadRelease` is now `lake run init`
- add `Solver` functions: `simplify`, `setLogic`, and `reset Assertions`