### PR TITLE
port cvc5's API test for proof features, minor fixes and improvements

### DIFF
--- a/PreBuild.lean
+++ b/PreBuild.lean
@@ -85,6 +85,12 @@ def Enum.writeToLean (e : Enum) (skipIfDefs := true) : IO Unit := do
     [],
     ["instance : ToString ", e.ident, " := ⟨", e.ident, ".toString⟩"],
     [],
+    ["/-- Produces a hash. -/"],
+    ["@[extern \"", e.toExternPref, "_hash\"]"],
+    ["protected opaque hash : ", e.ident, " → UInt64"],
+    [],
+    ["instance : Hashable ", e.ident, " := ⟨", e.ident, ".hash⟩"],
+    [],
     ["end ", e.ident],
   ]
 

--- a/PreBuild.lean
+++ b/PreBuild.lean
@@ -75,7 +75,7 @@ def Enum.writeToLean (e : Enum) (skipIfDefs := true) : IO Unit := do
       continue
     v.writeToLean h (pref ++ "  ")
   wlns [
-    ["deriving Inhabited, Repr, BEq, Hashable"],
+    ["deriving Inhabited, Repr, BEq"],
     [],
     ["namespace ", e.ident],
     [],

--- a/cvc5/Kind.lean
+++ b/cvc5/Kind.lean
@@ -5749,6 +5749,12 @@ protected opaque toString : Kind → String
 
 instance : ToString Kind := ⟨Kind.toString⟩
 
+/-- Produces a hash. -/
+@[extern "kind_hash"]
+protected opaque hash : Kind → UInt64
+
+instance : Hashable Kind := ⟨Kind.hash⟩
+
 end Kind
 
 /--
@@ -5967,5 +5973,11 @@ namespace SortKind
 protected opaque toString : SortKind → String
 
 instance : ToString SortKind := ⟨SortKind.toString⟩
+
+/-- Produces a hash. -/
+@[extern "sortKind_hash"]
+protected opaque hash : SortKind → UInt64
+
+instance : Hashable SortKind := ⟨SortKind.hash⟩
 
 end SortKind

--- a/cvc5/Kind.lean
+++ b/cvc5/Kind.lean
@@ -5739,7 +5739,7 @@ inductive Kind where
     - Solver::mkOp(Kind, const std::vector<uint32_t>&) const
   -/
   | INST_PATTERN_LIST
-deriving Inhabited, Repr, BEq, Hashable
+deriving Inhabited, Repr, BEq
 
 namespace Kind
 
@@ -5964,7 +5964,7 @@ inductive SortKind where
     - Solver::mkUninterpretedSort(const std::optional<std::string>&) const
   -/
   | UNINTERPRETED_SORT
-deriving Inhabited, Repr, BEq, Hashable
+deriving Inhabited, Repr, BEq
 
 namespace SortKind
 

--- a/cvc5/ProofRule.lean
+++ b/cvc5/ProofRule.lean
@@ -2343,7 +2343,7 @@ inductive ProofRule where
   -/
   | ALETHE_RULE
   | UNKNOWN
-deriving Inhabited, Repr, BEq, Hashable
+deriving Inhabited, Repr, BEq
 
 namespace ProofRule
 
@@ -5544,7 +5544,7 @@ inductive ProofRewriteRule where
   Auto-generated from RARE rule sets-card-emp 
   -/
   | SETS_CARD_EMP
-deriving Inhabited, Repr, BEq, Hashable
+deriving Inhabited, Repr, BEq
 
 namespace ProofRewriteRule
 

--- a/cvc5/ProofRule.lean
+++ b/cvc5/ProofRule.lean
@@ -2353,6 +2353,12 @@ protected opaque toString : ProofRule → String
 
 instance : ToString ProofRule := ⟨ProofRule.toString⟩
 
+/-- Produces a hash. -/
+@[extern "proofRule_hash"]
+protected opaque hash : ProofRule → UInt64
+
+instance : Hashable ProofRule := ⟨ProofRule.hash⟩
+
 end ProofRule
 
 /--
@@ -5547,5 +5553,11 @@ namespace ProofRewriteRule
 protected opaque toString : ProofRewriteRule → String
 
 instance : ToString ProofRewriteRule := ⟨ProofRewriteRule.toString⟩
+
+/-- Produces a hash. -/
+@[extern "proofRewriteRule_hash"]
+protected opaque hash : ProofRewriteRule → UInt64
+
+instance : Hashable ProofRewriteRule := ⟨ProofRewriteRule.hash⟩
 
 end ProofRewriteRule

--- a/cvc5/SkolemId.lean
+++ b/cvc5/SkolemId.lean
@@ -778,7 +778,7 @@ inductive SkolemId where
   Indicates this is not a skolem. 
   -/
   | NONE
-deriving Inhabited, Repr, BEq, Hashable
+deriving Inhabited, Repr, BEq
 
 namespace SkolemId
 

--- a/cvc5/SkolemId.lean
+++ b/cvc5/SkolemId.lean
@@ -788,4 +788,10 @@ protected opaque toString : SkolemId → String
 
 instance : ToString SkolemId := ⟨SkolemId.toString⟩
 
+/-- Produces a hash. -/
+@[extern "skolemId_hash"]
+protected opaque hash : SkolemId → UInt64
+
+instance : Hashable SkolemId := ⟨SkolemId.hash⟩
+
 end SkolemId

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -841,6 +841,16 @@ Create operators with `mkOp`.
 -/
 extern_def!? mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
 
+/-- Create a free constant.
+
+Note that the returned term is always fresh, even if the same arguments were provided on a previous
+call to `mkConst`.
+
+- `sort` The sort of the constant.
+- `symbol` The name of the constant (optional).
+-/
+extern_def mkConst : TermManager → (sort : cvc5.Sort) → (symbol: String := "") → Term
+
 end TermManager
 
 namespace Solver

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -87,10 +87,6 @@ instance Solver.instNonemptySolver : Nonempty Solver := SolverImpl.property
 /-- Solver error/state-monad transformer. -/
 abbrev SolverT m := ExceptT Error (StateT Solver m)
 
-namespace SolverT
-
-end SolverT
-
 /-- Solver error/state-monad wrapped in `IO`. -/
 abbrev SolverM := SolverT IO
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -848,15 +848,21 @@ Create operators with `mkOp`.
 -/
 extern_def!? mkTermOfOp : TermManager → (op : Op) → (children : Array Term := #[]) → Except Error Term
 
-/-- Create a free constant.
+/-- **THIS FUNCTION MUST NOT BE EXPOSED.**
 
-Note that the returned term is always fresh, even if the same arguments were provided on a previous
-call to `mkConst`.
+**It produces a different (fresh) term every time it's called which is really bad for purity.**
+
+Create a free constant.
+
+Note that the returned term is always fresh, even if the same arguments were provided on a
+previous call to `mkConst`.
 
 - `sort` The sort of the constant.
 - `symbol` The name of the constant (optional).
 -/
-extern_def mkConst : TermManager → (sort : cvc5.Sort) → (symbol: String := "") → Term
+private
+def mkConst (_ : TermManager) (_ : cvc5.Sort) (_ : String := "") : Term :=
+  panic! "illegal call to `cvc5.TermManager.mkConst"
 
 end TermManager
 
@@ -928,11 +934,8 @@ SMT-LIB:
 - `symbol`: The name of the function.
 - `sorts`: The sorts of the parameters to this function.
 - `sort`: The sort of the return value of this function.
-- `fresh`: If true, then this method always returns a new Term.
-           Otherwise, this method will always return the same Term
-           for each call with the given sorts and symbol where fresh is false.
 -/
-extern_def declareFun (symbol : String) (sorts : Array cvc5.Sort) (sort : cvc5.Sort) (fresh := true) : SolverT m Term
+extern_def declareFun (symbol : String) (sorts : Array cvc5.Sort) (sort : cvc5.Sort) : SolverT m Term
 
 /-- Assert a formula.
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -89,11 +89,6 @@ abbrev SolverT m := ExceptT Error (StateT Solver m)
 
 namespace SolverT
 
-instance SolverT.instMonadLift [Monad m] : MonadLift m (SolverT m) where
-  monadLift code state := do
-    let res ← code
-    return (.ok res, state)
-
 end SolverT
 
 /-- Solver error/state-monad wrapped in `IO`. -/

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -940,7 +940,7 @@ SMT-LIB:
 - `sorts`: The sorts of the parameters to this function.
 - `sort`: The sort of the return value of this function.
 -/
-extern_def declareFun (symbol : String) (sorts : Array cvc5.Sort) (sort : cvc5.Sort) : SolverT m Term
+extern_def declareFun (symbol : String) (sorts : Array cvc5.Sort) (sort : cvc5.Sort) (fresh := true) : SolverT m Term
 
 /-- Assert a formula.
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -935,6 +935,8 @@ SMT-LIB:
 - `symbol`: The name of the function.
 - `sorts`: The sorts of the parameters to this function.
 - `sort`: The sort of the return value of this function.
+- `fresh`: If true, then this method always returns a new Term. Otherwise, this method will always
+  return the same Term for each call with the given sorts and symbol where fresh is false.
 -/
 extern_def declareFun (symbol : String) (sorts : Array cvc5.Sort) (sort : cvc5.Sort) (fresh := true) : SolverT m Term
 

--- a/cvc5/Solver.lean
+++ b/cvc5/Solver.lean
@@ -148,6 +148,11 @@ private def mkExceptOkU32 : UInt32 → Except Error UInt32 :=
   .ok
 
 /-- Only used by FFI to inject values. -/
+@[export except_ok_u16]
+private def mkExceptOkU16 : UInt16 → Except Error UInt16 :=
+  .ok
+
+/-- Only used by FFI to inject values. -/
 @[export except_ok_u8]
 private def mkExceptOkU8 : UInt8 → Except Error UInt8 :=
   .ok

--- a/cvc5Test/Init.lean
+++ b/cvc5Test/Init.lean
@@ -127,10 +127,10 @@ namespace Test
 
 scoped syntax
   docComment ?
-  "test! " ("[" declId ", " declId "] ")? (ident " => ")? term : command
+  "test! " ("[" declId ", " declId "] ")? ("smt ")? (ident " => ")? term : command
 scoped syntax
   docComment ?
-  "test? " ("[" declId ", " declId "] ")? (ident " => ")? term : command
+  "test? " ("[" declId ", " declId "] ")? ("smt ")? (ident " => ")? term : command
 
 macro_rules
 | `(command|
@@ -159,6 +159,13 @@ macro_rules
 -- )
 | `(command|
   $[ $outputComment:docComment ]?
+  test! $[ [ $fileId:ident , $testId:ident ] ]? smt $tm:ident => $code:term
+) => `(
+  $[$outputComment]?
+  test! $[ [ $fileId, $testId ] ]? $tm => cvc5.Solver.run! $tm $code
+)
+| `(command|
+  $[ $outputComment:docComment ]?
   test! $[ [ $fileId:ident , $testId:ident ] ]? $code:term
 ) => `(
   $[$outputComment]?
@@ -180,6 +187,13 @@ macro_rules
 --     Solver.runWith! $tm do
 --       $code:term
 -- )
+| `(command|
+  $[ $outputComment:docComment ]?
+  test? $[ [ $fileId:ident , $testId:ident ] ]? smt $tm:ident => $code:term
+) => `(
+  $[$outputComment]?
+  test? $[ [ $fileId, $testId ] ]? $tm => cvc5.Solver.run! $tm $code
+)
 | `(command| $[$outputComment]? test? $[ [ $fileId, $testId ] ]? $code:term) => `(
   $[$outputComment]?
   test? $[ [ $fileId, $testId ] ]? _tm => $code

--- a/cvc5Test/Init.lean
+++ b/cvc5Test/Init.lean
@@ -113,7 +113,7 @@ def runWith! [Inhabited α] (tm : TermManager) (query : SolverM α) : IO α := d
   match ← Solver.run tm query with
   | .ok res => return res
   | .error err =>
-    IO.eprintln err.toString
+    IO.eprintln err
     return default
 
 def runIO! [Inhabited α] (query : SolverM α) : IO α := do

--- a/cvc5Test/Unit/ApiProof.lean
+++ b/cvc5Test/Unit/ApiProof.lean
@@ -23,10 +23,10 @@ def createProof (tm : TermManager) : SolverM Proof := do
   let uToIntSort ← tm.mkFunctionSort #[uSort] intSort
   let intPredSort ← tm.mkFunctionSort #[intSort] boolSort
 
-  let x := tm.mkConst uSort "x"
-  let y := tm.mkConst uSort "y"
-  let f := tm.mkConst uToIntSort "f"
-  let p := tm.mkConst intPredSort "p"
+  let x ← declareFun "x" #[] uSort
+  let y ← declareFun "y" #[] uSort
+  let f ← declareFun "f" #[uSort] intSort
+  let p ← declareFun "p" #[intSort] boolSort
   let zero := tm.mkInteger 0
   let one := tm.mkInteger 1
   let f_x ← tm.mkTerm Kind.APPLY_UF #[f, x]
@@ -53,7 +53,7 @@ def createRewriteProof (tm : TermManager) : SolverM Proof := do
   setOption "produce-proofs" "true"
   setOption "proof-granularity" "dsl-rewrite"
   let intSort := tm.getIntegerSort
-  let x := tm.mkConst intSort "x"
+  let x ← declareFun "x" #[] intSort
   let zero := tm.mkInteger 0
   let geq ← tm.mkTerm Kind.GEQ #[x, zero]
   let leq ← tm.mkTerm Kind.LEQ #[zero, x]

--- a/cvc5Test/Unit/ApiProof.lean
+++ b/cvc5Test/Unit/ApiProof.lean
@@ -1,0 +1,135 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
+import cvc5Test.Init
+
+/-! # Black box testing of the guards of the Lean API functions
+
+- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_proof_black.cpp>
+-/
+
+namespace cvc5.Test
+
+section open Solver
+
+def createProof (tm : TermManager) : SolverM Proof := do
+  setOption "produce-proofs" "true"
+  let uSort := tm.mkUninterpretedSort "u"
+  let intSort := tm.getIntegerSort
+  let boolSort := tm.getBooleanSort
+  let uToIntSort ← tm.mkFunctionSort #[uSort] intSort
+  let intPredSort ← tm.mkFunctionSort #[intSort] boolSort
+
+  let x := tm.mkConst uSort "x"
+  let y := tm.mkConst uSort "y"
+  let f := tm.mkConst uToIntSort "f"
+  let p := tm.mkConst intPredSort "p"
+  let zero := tm.mkInteger 0
+  let one := tm.mkInteger 1
+  let f_x ← tm.mkTerm Kind.APPLY_UF #[f, x]
+  let f_y ← tm.mkTerm Kind.APPLY_UF #[f, y]
+  let sum ← tm.mkTerm Kind.ADD #[f_x, f_y]
+  let p_0 ← tm.mkTerm Kind.APPLY_UF #[p, zero]
+  let p_f_y ← tm.mkTerm Kind.APPLY_UF #[p, f_y]
+  tm.mkTerm Kind.GT #[zero, f_x] >>= assertFormula
+  tm.mkTerm Kind.GT #[zero, f_y] >>= assertFormula
+  tm.mkTerm Kind.GT #[sum, one] >>= assertFormula
+  assertFormula p_0
+  p_f_y.not >>= assertFormula
+  let res ← checkSat
+  if ¬ res.isUnsat then
+    fail "expected unsat result in proof creation"
+
+  let proof ← getProof
+  if h : 0 < proof.size then
+    return proof[0]
+  else
+    fail "expected non-empty proof"
+
+def createRewriteProof (tm : TermManager) : SolverM Proof := do
+  setOption "produce-proofs" "true"
+  setOption "proof-granularity" "dsl-rewrite"
+  let intSort := tm.getIntegerSort
+  let x := tm.mkConst intSort "x"
+  let zero := tm.mkInteger 0
+  let geq ← tm.mkTerm Kind.GEQ #[x, zero]
+  let leq ← tm.mkTerm Kind.LEQ #[zero, x]
+  tm.mkTerm Kind.DISTINCT #[geq, leq] >>= assertFormula
+  let res ← checkSat
+  if ¬ res.isUnsat then
+    fail "expected unsat result in rewrite proof creation"
+
+  let proof ← getProof
+  if h : 0 < proof.size then
+    return proof[0]
+  else
+    fail "expected non-empty rewrite proof"
+
+end
+
+test![TestApiBlackProof, nullProof] do
+  let proof := Proof.null ()
+  assertEq proof.getRule ProofRule.UNKNOWN
+  -- skipping test in original file for the hash being equal to the constructor index
+  assertTrue proof.getResult.isNull
+  assertTrue proof.getChildren.isEmpty
+  assertTrue proof.getArguments.isEmpty
+
+test![TestApiBlackProof, getRule] smt tm => do
+  let proof ← createProof tm
+  assertEq proof.getRule ProofRule.SCOPE
+
+test![TestApiBlackProof, getRewriteRule] smt tm => do
+  let mut proof ← createRewriteProof tm
+  assertError
+    "expected `getRule()` to return `DSL_REWRITE` or `THEORY_REWRITE`, got SCOPE instead."
+    proof.getRewriteRule
+
+  let mut rule : Option ProofRule := none
+  let mut stack : Array Proof := #[proof]
+
+  for _ in [0:1000] do
+    if let some ProofRule.DSL_REWRITE := rule then
+      break
+    if h : 0 < stack.size then
+      proof := stack[stack.size - 1]
+      rule := proof.getRule
+      stack := stack.pop ++ proof.getChildren
+    else fail "expected `DSL_REWRITE` proof rule or non-empty stack"
+
+  assertOkDiscard proof.getRewriteRule
+
+test![TestApiBlackProof, getResult] tm => do
+  let proof ← createProof tm
+  let _ := proof.getResult
+
+test![TestApiBlackProof, getChildren] tm => do
+  let proof ← createProof tm
+  let children := proof.getChildren
+  assertFalse children.isEmpty
+
+test![TestApiBlackProof, getArguments] tm => do
+  let proof ← createProof tm
+  let _ := proof.getArguments
+
+test![TestApiBlackProof, equalhash] tm => do
+  let x ← createProof tm
+  let kids := x.getChildren
+  if h : 0 < kids.size then
+    let y := kids[0]
+    let z := Proof.null ()
+
+    assertTrue (x == x)
+    assertFalse (x != x)
+    assertFalse (x == y)
+    assertTrue (x != y)
+    assertFalse (x == z)
+    assertTrue (x != z)
+
+    assertTrue (x.hash == x.hash)
+    assertFalse (x.hash == y.hash)
+  else
+    IO.eprintln "expected at least one kid"

--- a/cvc5Test/Unit/ApiSort.lean
+++ b/cvc5Test/Unit/ApiSort.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
 import cvc5Test.Init
 
 /-! # Black box testing of the guards of the Lean API functions

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -898,9 +898,11 @@ extern "C" uint8_t proof_getRule(lean_obj_arg p)
   return static_cast<uint32_t>(proof_unbox(p)->getRule());
 }
 
-extern "C" uint16_t proof_getRewriteRule(lean_obj_arg p)
+extern "C" lean_obj_res proof_getRewriteRule(lean_obj_arg p)
 {
-  return static_cast<uint32_t>(proof_unbox(p)->getRewriteRule());
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok_u32(static_cast<uint32_t>(proof_unbox(p)->getRewriteRule()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 extern "C" lean_obj_res proof_getResult(lean_obj_arg p)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -138,7 +138,7 @@ extern "C" lean_obj_res proofRewriteRule_toString(uint16_t prr)
       std::to_string(static_cast<ProofRewriteRule>(prr)).c_str());
 }
 
-extern "C" uint64_t proofRewriteRule_hash(uint8_t prr)
+extern "C" uint64_t proofRewriteRule_hash(uint16_t prr)
 {
   return std::hash<ProofRewriteRule>()(static_cast<ProofRewriteRule>(prr));
 }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1354,6 +1354,7 @@ extern "C" lean_obj_res solver_declareFun(lean_obj_arg inst,
                                           lean_obj_arg symbol,
                                           lean_obj_arg sorts,
                                           lean_obj_arg sort,
+                                          uint8_t fresh,
                                           lean_obj_arg solver)
 {
   CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
@@ -1364,7 +1365,7 @@ extern "C" lean_obj_res solver_declareFun(lean_obj_arg inst,
         lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
   }
   Term f = solver_unbox(solver)->declareFun(
-      lean_string_cstr(symbol), ss, *sort_unbox(sort), false);
+      lean_string_cstr(symbol), ss, *sort_unbox(sort), bool_unbox(fresh));
   return solver_val(
       lean_box(0), inst, lean_box(0), term_box(new Term(f)), solver);
   CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1223,6 +1223,8 @@ extern "C" lean_obj_res termManager_mkTermOfOp(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
+// This function is not part of the *public* `lean-cvc5` API: it produces a different (fresh) term
+// every time it's called which is really bad for purity.
 extern "C" lean_obj_res termManager_mkConst(lean_obj_arg tm,
                                             lean_obj_arg sort,
                                             lean_obj_arg symbol)
@@ -1349,7 +1351,6 @@ extern "C" lean_obj_res solver_declareFun(lean_obj_arg inst,
                                           lean_obj_arg symbol,
                                           lean_obj_arg sorts,
                                           lean_obj_arg sort,
-                                          uint8_t fresh,
                                           lean_obj_arg solver)
 {
   CVC5_LEAN_API_TRY_CATCH_SOLVER_BEGIN;
@@ -1360,7 +1361,7 @@ extern "C" lean_obj_res solver_declareFun(lean_obj_arg inst,
         lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
   }
   Term f = solver_unbox(solver)->declareFun(
-      lean_string_cstr(symbol), ss, *sort_unbox(sort), bool_unbox(fresh));
+      lean_string_cstr(symbol), ss, *sort_unbox(sort), false);
   return solver_val(
       lean_box(0), inst, lean_box(0), term_box(new Term(f)), solver);
   CVC5_LEAN_API_TRY_CATCH_SOLVER_END(inst, solver);

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -107,14 +107,29 @@ extern "C" lean_obj_res kind_toString(uint16_t k)
   return lean_mk_string(std::to_string(static_cast<Kind>(k - 2)).c_str());
 }
 
+extern "C" uint64_t kind_hash(uint8_t k)
+{
+  return std::hash<Kind>()(static_cast<Kind>(k));
+}
+
 extern "C" lean_obj_res sortKind_toString(uint8_t sk)
 {
   return lean_mk_string(std::to_string(static_cast<SortKind>(sk - 2)).c_str());
 }
 
+extern "C" uint64_t sortKind_hash(uint8_t sk)
+{
+  return std::hash<SortKind>()(static_cast<SortKind>(sk));
+}
+
 extern "C" lean_obj_res proofRule_toString(uint8_t pr)
 {
   return lean_mk_string(std::to_string(static_cast<ProofRule>(pr)).c_str());
+}
+
+extern "C" uint64_t proofRule_hash(uint8_t pr)
+{
+  return std::hash<ProofRule>()(static_cast<ProofRule>(pr));
 }
 
 extern "C" lean_obj_res proofRewriteRule_toString(uint16_t prr)
@@ -123,9 +138,18 @@ extern "C" lean_obj_res proofRewriteRule_toString(uint16_t prr)
       std::to_string(static_cast<ProofRewriteRule>(prr)).c_str());
 }
 
+extern "C" uint64_t proofRewriteRule_hash(uint8_t prr)
+{
+  return std::hash<ProofRewriteRule>()(static_cast<ProofRewriteRule>(prr));
+}
+
 extern "C" lean_obj_res skolemId_toString(uint8_t si)
 {
   return lean_mk_string(std::to_string(static_cast<SkolemId>(si)).c_str());
+}
+extern "C" uint64_t skolemId_hash(uint8_t si)
+{
+  return std::hash<SkolemId>()(static_cast<SkolemId>(si));
 }
 
 static void result_finalize(void* obj) { delete static_cast<Result*>(obj); }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -12,6 +12,8 @@ extern "C" lean_obj_res except_ok_bool(uint8_t val);
 
 extern "C" lean_obj_res except_ok_u32(uint32_t val);
 
+extern "C" lean_obj_res except_ok_u16(uint8_t val);
+
 extern "C" lean_obj_res except_ok_u8(uint8_t val);
 
 extern "C" lean_obj_res except_err(lean_obj_arg alpha, lean_obj_arg msg);
@@ -902,7 +904,7 @@ extern "C" uint8_t proof_getRule(lean_obj_arg p)
 extern "C" lean_obj_res proof_getRewriteRule(lean_obj_arg p)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok_u32(static_cast<uint32_t>(proof_unbox(p)->getRewriteRule()));
+  return except_ok_u16(static_cast<int>(proof_unbox(p)->getRewriteRule()));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -147,6 +147,7 @@ extern "C" lean_obj_res skolemId_toString(uint8_t si)
 {
   return lean_mk_string(std::to_string(static_cast<SkolemId>(si)).c_str());
 }
+
 extern "C" uint64_t skolemId_hash(uint8_t si)
 {
   return std::hash<SkolemId>()(static_cast<SkolemId>(si));


### PR DESCRIPTION
- port cvc5's API test for proof features
- add `TermManager.mkConst` (used by the proof API test)
- fix `Proof.getRewriteRule`'s signature and doc (can fail on some inputs)
- add `hash` function on all generated enums: (sort) kind, proof (rewrite) rules, and skolem id