### PR TITLE
chore: 4.18 and build with `lake build` only -- no manual script running

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,7 +39,7 @@ jobs:
         auto-config: false
         use-github-cache: false
     - name: Download cvc5 Release
-      run: lake run init
+      run: lake update
     - name: Build and Test lean-cvc5
       uses: leanprover/lean-action@v1
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,8 +38,6 @@ jobs:
       with:
         auto-config: false
         use-github-cache: false
-    - name: Download cvc5 Release
-      run: lake update
     - name: Build and Test lean-cvc5
       uses: leanprover/lean-action@v1
       with:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require smt from git "https://github.com/abdoo8080/lean-cvc5.git" @ "main"
 Build this library by running the `init` script before `lake`-building:
 
 ```text
-lake run init
+lake update
 [...]
 lake build
 [...]

--- a/cvc5Test/Unit/ApiOp.lean
+++ b/cvc5Test/Unit/ApiOp.lean
@@ -159,7 +159,7 @@ test! tm => do
   let indices := #[0, 3, 2, 0, 1, 2];
   let tupleProject ← tm.mkOp Kind.TUPLE_PROJECT indices;
   for idx in [0 : indices.size] do
-    check tupleProject idx (indices.get! idx)
+    check tupleProject idx (indices[idx]!)
 
 /-
 Not sure what to do for the end of the test below. Original test is

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -55,8 +55,10 @@ def url : String := s!"{cvc5.url}/{cvc5.version}/{cvc5.zip.fileName}"
 
 end zip
 
+/-- Prefix shared by all source directories for this os and architecture. -/
+def srcDirNamePref : String := cvc5.zip.stem
 /-- Name of the directory that eventually stores the cvc5 sources. -/
-def srcDirName : FilePath := s!"{cvc5.zip.stem}-{cvc5.version}"
+def srcDirName : FilePath := s!"{srcDirNamePref}-{cvc5.version}"
 /-- Path to the directory that eventually stores the cvC5 sources. -/
 def srcDir (root : FilePath) : FilePath := root / srcDirName
 
@@ -139,14 +141,15 @@ extern_lib cvc5ffi pkg := do
   else
     logV "setting up cvc5"
     if ← pkg.buildDir.pathExists then
-      -- remove any directory that starts with `cvc5.osArchTarget`
+      -- remove any directory that starts with `cvc5.srcDirNamePref`
       for entry in ← pkg.buildDir.readDir do
         let path := entry.path
         if ← path.isDir then
           let rm :=
-            path.fileName.map (fun s => s.startsWith cvc5.osArchTarget)
+            path.fileName.map (fun s => s.startsWith cvc5.srcDirNamePref)
             |>.getD false
           if rm then IO.FS.removeDirAll path
+        else
     let zipFile := cvc5.zip.file pkg.buildDir
     logV s!"- download `{cvc5.zip.url}`"
     download cvc5.zip.url zipFile

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -69,7 +69,6 @@ post_update pkg do
   let libDir := pkg.leanLibDir
   if ← libDir.pathExists then
     for file in ← libDir.readDir do
-      logInfo s!"looking at {file.path}"
       if file.root = libDir ∧ file.fileName.startsWith "libffi" then
         log s!"removing ffi build file {file.path}"
         IO.FS.removeFile file.path

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -149,7 +149,6 @@ extern_lib cvc5ffi pkg := do
             path.fileName.map (fun s => s.startsWith cvc5.srcDirNamePref)
             |>.getD false
           if rm then IO.FS.removeDirAll path
-        else
     let zipFile := cvc5.zip.file pkg.buildDir
     logV s!"- download `{cvc5.zip.url}`"
     download cvc5.zip.url zipFile

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -56,40 +56,6 @@ def generateEnums (cppDir : FilePath) (pkg : NPackage _package.name) : IO Unit :
 ```\
     "
 
-/-- Post-update script script.
-
-- remove `libffi.*` files if any;
-- download cvc5 release files;
-- generate/update lean-enumerations.
--/
-post_update pkg do
-  let log {m : Type → Type} [Monad m] [MonadLog m] (s : String) : m _ :=
-    logVerbose s!"{s}"
-  -- remove files that are sensitive to API/cvc5 version changes
-  let libDir := pkg.leanLibDir
-  if ← libDir.pathExists then
-    for file in ← libDir.readDir do
-      if file.root = libDir ∧ file.fileName.startsWith "libffi" then
-        log s!"removing ffi build file {file.path}"
-        IO.FS.removeFile file.path
-  -- download/unzip cvc5 archive if needed
-  let cvc5ZipDir := pkg.buildDir / s!"cvc5-{cvc5.target}"
-  if ← cvc5ZipDir.pathExists then
-    log s!"cvc5 C++ interface up to date, nothing to do"
-  else
-    let zipUrl := s!"{cvc5.url}/{cvc5.version}/cvc5-{cvc5.target}.zip"
-    log s!"downloading `{zipUrl}`"
-    let zipPath := cvc5ZipDir.addExtension "zip"
-    if ← cvc5ZipDir.pathExists then
-      IO.FS.removeDirAll cvc5ZipDir
-    download zipUrl zipPath
-    log s!"extracting `{zipPath}`"
-    unzip zipPath pkg.buildDir
-    IO.FS.removeFile zipPath
-    log s!"generating lean-level enum-like types"
-    generateEnums (cvc5ZipDir / "include" / "cvc5") pkg
-  log "done"
-
 def Lake.compileStaticLib'
   (libFile : FilePath) (oFiles : Array FilePath)
   (ar : FilePath := "ar")
@@ -123,6 +89,32 @@ target ffi.o pkg : FilePath := do
 def libs := #["cadical", "cvc5", "cvc5parser", "gmp", "gmpxx", "picpoly", "picpolyxx"]
 
 extern_lib libffi pkg := do
+  let log {m : Type → Type} [Monad m] [MonadLog m] (s : String) : m _ :=
+    logVerbose s!"{s}"
+  -- remove files that are sensitive to API/cvc5 version changes
+  let libDir := pkg.leanLibDir
+  if ← libDir.pathExists then
+    for file in ← libDir.readDir do
+      if file.root = libDir ∧ file.fileName.startsWith "libffi" then
+        log s!"removing ffi build file {file.path}"
+        IO.FS.removeFile file.path
+  -- download/unzip cvc5 archive if needed
+  let cvc5ZipDir := pkg.buildDir / s!"cvc5-{cvc5.target}"
+  if ← cvc5ZipDir.pathExists then
+    log s!"cvc5 C++ interface up to date, nothing to do"
+  else
+    let zipUrl := s!"{cvc5.url}/{cvc5.version}/cvc5-{cvc5.target}.zip"
+    log s!"downloading `{zipUrl}`"
+    let zipPath := cvc5ZipDir.addExtension "zip"
+    if ← cvc5ZipDir.pathExists then
+      IO.FS.removeDirAll cvc5ZipDir
+    download zipUrl zipPath
+    log s!"extracting `{zipPath}`"
+    unzip zipPath pkg.buildDir
+    IO.FS.removeFile zipPath
+    log s!"generating lean-level enum-like types"
+    generateEnums (cvc5ZipDir / "include" / "cvc5") pkg
+  log "done"
   let ffiO ← fetch (pkg.target ``ffi.o)
   let libs := libs.map (pure <| pkg.buildDir / s!"cvc5-{cvc5.target}" / "lib" / nameToStaticLib ·)
   let libFile := pkg.nativeLibDir / nameToStaticLib "ffi"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -20,20 +20,50 @@ def Lake.unzip (file : FilePath) (dir : FilePath) : LogIO PUnit := do
     args := #["-d", dir.toString, file.toString]
   }
 
-def cvc5.url := "https://github.com/abdoo8080/cvc5/releases/download"
+namespace cvc5
+def url := "https://github.com/abdoo8080/cvc5/releases/download"
 
-def cvc5.version := "802460d"
+def version := "802460d"
 
-def cvc5.os :=
+def os :=
   if System.Platform.isWindows then "Win64"
   else if System.Platform.isOSX then "macOS"
   else "Linux"
 
-def cvc5.arch :=
+def arch :=
   if System.Platform.target.startsWith "x86_64" then "x86_64"
   else "arm64"
 
-def cvc5.target := s!"{os}-{arch}-static"
+def osArchTarget := s!"{os}-{arch}-static"
+
+namespace zip
+
+def stem : String := "cvc5-" ++ osArchTarget
+
+/-- Name of the directory the archive unzips to. -/
+def extractedDirName : FilePath := cvc5.zip.stem
+/-- Path to the directory the archive unzips to. -/
+def extractedDir (root : FilePath) : FilePath := root / extractedDirName
+
+/-- Name of the archive. -/
+def fileName : FilePath := FilePath.addExtension cvc5.zip.stem "zip"
+/-- Path to the archive. -/
+def file (root : FilePath) : FilePath := root / fileName
+
+/-- URL of the cvc5 C++ archive. -/
+def url : String := s!"{cvc5.url}/{cvc5.version}/{cvc5.zip.fileName}"
+
+end zip
+
+/-- Name of the directory that eventually stores the cvc5 sources. -/
+def srcDirName : FilePath := s!"{cvc5.zip.stem}-{cvc5.version}"
+/-- Path to the directory that eventually stores the cvC5 sources. -/
+def srcDir (root : FilePath) : FilePath := root / srcDirName
+
+/-- Name of the C++ library `leanc` will bind. -/
+def libFfiName := "cvc5ffi"
+
+end cvc5
 
 open IO.Process in
 def generateEnums (cppDir : FilePath) (pkg : NPackage _package.name) : IO Unit := do
@@ -81,41 +111,55 @@ target ffi.o pkg : FilePath := do
       "-std=c++17",
       "-stdlib=libc++",
       "-I", (← getLeanIncludeDir).toString,
-      "-I", (pkg.buildDir / s!"cvc5-{cvc5.target}" / "include").toString,
+      "-I", (cvc5.srcDir pkg.buildDir / "include").toString,
       "-fPIC"
     ]
     buildO oFile srcJob flags
 
 def libs := #["cadical", "cvc5", "cvc5parser", "gmp", "gmpxx", "picpoly", "picpolyxx"]
 
-extern_lib libffi pkg := do
-  let log {m : Type → Type} [Monad m] [MonadLog m] (s : String) : m _ :=
-    logVerbose s!"{s}"
-  -- remove files that are sensitive to API/cvc5 version changes
+extern_lib cvc5ffi pkg := do
+  let logV {m : Type → Type} [Monad m] [MonadLog m] (s : String) : m PUnit :=
+    logVerbose s!"[{pkg.name}] {s}"
+  -- remove files that are sensitive to API/cvc5 version changes, we're only here because this is
+  -- the first build or `ffi/ffi.cpp` has changed
+  logV "running"
   let libDir := pkg.leanLibDir
+  logV s!"checking `{libDir}`"
   if ← libDir.pathExists then
-    for file in ← libDir.readDir do
-      if file.root = libDir ∧ file.fileName.startsWith "libffi" then
-        log s!"removing ffi build file {file.path}"
-        IO.FS.removeFile file.path
+    let libFfiNamePref := s!"lib{cvc5.libFfiName}"
+    for entry in ← libDir.readDir do
+      if entry.root = libDir ∧ entry.fileName.startsWith libFfiNamePref then
+        logV s!"removing ffi build file {entry.path}"
+        IO.FS.removeFile entry.path
   -- download/unzip cvc5 archive if needed
-  let cvc5ZipDir := pkg.buildDir / s!"cvc5-{cvc5.target}"
-  if ← cvc5ZipDir.pathExists then
-    log s!"cvc5 C++ interface up to date, nothing to do"
+  let srcDir := cvc5.srcDir pkg.buildDir
+  if ← srcDir.pathExists then
+    logV s!"cvc5 C++ interface up to date"
   else
-    let zipUrl := s!"{cvc5.url}/{cvc5.version}/cvc5-{cvc5.target}.zip"
-    log s!"downloading `{zipUrl}`"
-    let zipPath := cvc5ZipDir.addExtension "zip"
-    if ← cvc5ZipDir.pathExists then
-      IO.FS.removeDirAll cvc5ZipDir
-    download zipUrl zipPath
-    log s!"extracting `{zipPath}`"
-    unzip zipPath pkg.buildDir
-    IO.FS.removeFile zipPath
-    log s!"generating lean-level enum-like types"
-    generateEnums (cvc5ZipDir / "include" / "cvc5") pkg
-  log "done"
+    logV "setting up cvc5"
+    if ← pkg.buildDir.pathExists then
+      -- remove any directory that starts with `cvc5.orArchTarget`
+      for entry in ← pkg.buildDir.readDir do
+        let path := entry.path
+        if ← path.isDir then
+          let rm :=
+            path.fileName.map (fun s => s.startsWith cvc5.osArchTarget)
+            |>.getD false
+          if rm then IO.FS.removeDirAll path
+    let zipFile := cvc5.zip.file pkg.buildDir
+    logV s!"- download `{cvc5.zip.url}`"
+    download cvc5.zip.url zipFile
+    logV s!"- extracting to `{srcDir}`"
+    unzip zipFile pkg.buildDir
+    IO.FS.rename (cvc5.zip.extractedDir pkg.buildDir) srcDir
+    IO.FS.removeFile zipFile
+    let cppDir := srcDir / "include" / "cvc5"
+    logV s!"- generate lean-level enum-like types ← `{cppDir}`"
+    generateEnums cppDir pkg
+    logV "done"
   let ffiO ← fetch (pkg.target ``ffi.o)
-  let libs := libs.map (pure <| pkg.buildDir / s!"cvc5-{cvc5.target}" / "lib" / nameToStaticLib ·)
-  let libFile := pkg.nativeLibDir / nameToStaticLib "ffi"
+  logV s!"building FFI static library"
+  let libs := libs.map (pure <| srcDir / "lib" / nameToStaticLib ·)
+  let libFile := pkg.nativeLibDir / nameToStaticLib cvc5.libFfiName
   buildStaticLib' libFile (libs.push ffiO)

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -139,7 +139,7 @@ extern_lib cvc5ffi pkg := do
   else
     logV "setting up cvc5"
     if ← pkg.buildDir.pathExists then
-      -- remove any directory that starts with `cvc5.orArchTarget`
+      -- remove any directory that starts with `cvc5.osArchTarget`
       for entry in ← pkg.buildDir.readDir do
         let path := entry.path
         if ← path.isDir then

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.16.0
+leanprover/lean4:v4.18.0


### PR DESCRIPTION
The script downloading the cvc5 archive and performing the setup is now a part of the definition of the `extern_lib` for cvc5 ffi.

Previously, it was necessary to `lake run init` to retrieve the cvc5 archive and setup ffi. This made developing in/depending on `lean-cvc5` tedious as `lake build` would result in low-level C ffi errors.

Also, working on `lean-cvc5` was even more tedious as changing `ffi/ffi.cpp` caused the build to fail unless some specific `.lake/build/lib/libffi.*` files were deleted.

Last, the [reservoir page] reports an [error][build fail] on `4.16.0`. I'm not sure it comes (only) from the `lake run init` workflow but improving it will help, I assume.

- move the `init` script into the `extern_lib` for cvc5 ffi, meaning the pre-build script runs
  - on the first build, *e.g.* on a fresh clone
  - any subsequent build where `ffi/ffi.cpp` has changed (lean-cvc5 dev QoL improvement)

- the `init` script, now part of the `extern_lib`, has changed a bit:
  - `libffi.*` files in the library build dir are now `libcvc5ffi.*` to avoid potential clashes with other static libs
  - `libcvc5ffi.*` files are deleted when building the extern lib (first build or `ffi/ffi.cpp` has changed)
  - the directory containing the C++ sources now has the commit in its name, allowing to detect we don't need to re-download/extract the archive

    (when downloading the archive, we delete all directories that have a name starting with `cvc5-<os>-<arch>` so that they don't accumulate)

- some refactoring in `lakefile.lean` mostly for file/dir names/paths, and URLs
- bump to 4.18.0

As a result building (a project depending on) lean-cvc5 can always be done with just `lake build`, including the first build and builds running after a modification to `ffi/ffi.cpp`.

[reservoir page]: https://reservoir.lean-lang.org/@abdoo8080/cvc5
[build fail]: https://github.com/leanprover/reservoir/actions/runs/14574783254/job/40878758925#step:4:1