### PR TITLE
Bump to Lean v4.20.0-rc3

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -41,7 +41,7 @@ def generateEnums (cppDir : FilePath) (pkg : NPackage _package.name) : IO Unit :
     cmd := "lean"
     args := #[
       "--run", (pkg.srcDir / "PreBuild.lean").toString,
-      "--", -- arguments for `PreBuild.lean` binary: C++ source dir and lean target dir
+      -- arguments for `PreBuild.lean` binary: C++ source dir and lean target dir
       cppDir.toString, (pkg.srcDir / "cvc5").toString
     ]
   }
@@ -118,5 +118,5 @@ def libs := #["cadical", "cvc5", "cvc5parser", "gmp", "gmpxx", "picpoly", "picpo
 extern_lib libffi pkg := do
   let ffiO ← fetch (pkg.target ``ffi.o)
   let libs := libs.map (pure <| pkg.buildDir / s!"cvc5-{cvc5.target}" / "lib" / nameToStaticLib ·)
-  let libFile := pkg.nativeLibDir / nameToStaticLib "ffi"
+  let libFile := pkg.staticLibDir / nameToStaticLib "ffi"
   buildStaticLib' libFile (libs.push ffiO)

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.18.0
+leanprover/lean4:v4.20.0-rc3


### PR DESCRIPTION
`lean-cvc5` [currently doesn't work on macOS 15.4](https://leanprover.zulipchat.com/#narrow/channel/270676-lean4/topic/Linking.20issues.20when.20bumping.20.60lean-cvc5.60.20to.20v4.2E20.2E0-rc2/with/516163745) due to a bug in Lean that has been [fixed](https://github.com/leanprover/lean4/pull/8236) in `v4.20.0-rc3`.

This bumps the toolchain version such that `lean-cvc5` builds on macOS 15.4.

I think it will be necessary to merge this to be able to get `lean-smt` to build correctly (even on a branch) on `v4.20.0-rc3`. This is the case since `lake build` doesn't actually work for `lean-cvc5` on a fresh clone (it requires `lake run init`, which is not called automatically [anymore](https://github.com/abdoo8080/lean-cvc5/commit/fcb16b1feed8b1796810c888e50738da0d2faa33)) -- `lean-smt`'s build only seems to work when it manages to download the release build artifact for `lean-cvc5`. (Merging this should create the build artifact.)