### PR TITLE
`Result` tests from cvc5 API tests, autogen more enums 

### DIFF
--- a/cvc5.lean
+++ b/cvc5.lean
@@ -573,13 +573,30 @@ def getChildren (t : Term) : Array Term := Id.run do
   cts
 
 /-- Boolean negation. -/
-protected extern_def!? not : Term → Except Error Term
+protected extern_def!? not : (t : Term) → Except Error Term
 
 /-- Boolean and. -/
-protected extern_def!? and : Term → Term → Except Error Term
+protected extern_def!? and : (lft rgt : Term) → Except Error Term
 
 /-- Boolean or. -/
-protected extern_def!? or : Term → Term → Except Error Term
+protected extern_def!? or : (lft rgt : Term) → Except Error Term
+
+/-- Boolean exclusive or. -/
+protected extern_def!? xor : (lft rgt : Term) → Except Error Term
+
+/-- Equality. -/
+protected extern_def!? eq : (lft rgt : Term) → Except Error Term
+
+/-- Boolean implication. -/
+protected extern_def!? imp : (lft rgt : Term) → Except Error Term
+
+/-- If-then-else.
+
+- `cnd`: condition, must be a Boolean term;
+- `thn`: then-branch of some sort `S`;
+- `els`: else-branch of *the same* sort `S`.
+-/
+protected extern_def!? ite : (cnd thn els : Term) → Except Error Term
 
 /-- A string representation of this term. -/
 protected extern_def toString : Term → String

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -113,6 +113,11 @@ protected extern_def beq : Result → Result → Bool
 
 instance : BEq Result := ⟨Result.beq⟩
 
+/-- Hash function for cvc5 sorts. -/
+protected extern_def hash : Result → UInt64
+
+instance : Hashable Result := ⟨Result.hash⟩
+
 /-- True if this result is from a satisfiable `checkSat` or `checkSatAssuming` query. -/
 extern_def isSat : Result → Bool
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -835,7 +835,7 @@ with
 -/
 private extern_def mkRealFromString : TermManager → (s : String) → Except Error Term
 with
-  /-- Create a real-value term from numerator/denominator `Int`-s. -/
+  /-- Create a real-value term from a `Std.Internal.Rat`. -/
   mkRealOfRat (tm : TermManager) (rat : Std.Internal.Rat) : Term :=
     tm.mkRealFromString s!"{rat.num}/{rat.den}" |> Error.unwrap!
   /-- Create a real-value term from numerator/denominator `Int`-s. -/

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -108,6 +108,11 @@ end Error
 
 namespace Result
 
+/-- Comparison for structural equality. -/
+protected extern_def beq : Result → Result → Bool
+
+instance : BEq Result := ⟨Result.beq⟩
+
 /-- True if this result is from a satisfiable `checkSat` or `checkSatAssuming` query. -/
 extern_def isSat : Result → Bool
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -836,8 +836,18 @@ with
 private extern_def mkRealFromString : TermManager → (s : String) → Except Error Term
 with
   /-- Create a real-value term from numerator/denominator `Int`-s. -/
-  mkReal (tm : TermManager) (num : Int) (den : Int := 1) : Term :=
-    tm.mkRealFromString s!"{num}/{den}" |> Error.unwrap!
+  mkRealOfRat (tm : TermManager) (rat : Std.Internal.Rat) : Term :=
+    tm.mkRealFromString s!"{rat.num}/{rat.den}" |> Error.unwrap!
+  /-- Create a real-value term from numerator/denominator `Int`-s. -/
+  mkReal (tm : TermManager)
+    (num : Int) (den : Int := 1) (den_ne_0 : den ≠ 0 := by simp <;> omega)
+  : Term :=
+    let (num, den) :=
+      match h : den with
+      | .ofNat 0 => by contradiction
+      | .ofNat den => (num, den)
+      | .negSucc denMinus1 => (-num, denMinus1.succ)
+    tm.mkRealOfRat <| Std.Internal.mkRat num den
 
 /-- Create operator of Kind:
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -130,6 +130,16 @@ determine (un)satisfiability.
 -/
 extern_def isUnknown : Result → Bool
 
+/-- An explanation for an unknown query result.
+
+Note that if the result is (un)sat, this function returns `UnknownExplanation.UNKNOWN_REASON`.
+-/
+extern_def getUnknownExplanation : Result → UnknownExplanation
+with
+  /-- An explanation for an unknown query result, `none` if the result in not unknown. -/
+  getUnknownExplanation? (res : Result) : Option UnknownExplanation :=
+    if ¬ res.isUnknown then none else res.getUnknownExplanation
+
 /-- A string representation of this result. -/
 protected extern_def toString : Result → String
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -807,11 +807,26 @@ extern_def mkParamSort : TermManager → (symbol : String) → cvc5.Sort
 -/
 extern_def mkBoolean : TermManager → (b : Bool) → Term
 
-/-- Create an integer-value term. -/
-private extern_def mkIntegerFromString : TermManager → String → Except Error Term
+/-- Create an integer-value term.
+
+- `s`: the string representation of the constant, may represent an integer such as (`"123"`).
+-/
+private extern_def mkIntegerFromString : TermManager → (s : String) → Except Error Term
 with
+  /-- Create an integer-value term. -/
   mkInteger (tm : TermManager) : Int → Term :=
     Error.unwrap! ∘ tm.mkIntegerFromString ∘ toString
+
+/-- Create a real-value term.
+
+- `s`: the string representation of the constant, may represent an integer (`"123"`) or a real
+  constant (`"12.34"`, `"12/34"`).
+-/
+private extern_def mkRealFromString : TermManager → (s : String) → Except Error Term
+with
+  /-- Create a real-value term from numerator/denominator `Int`-s. -/
+  mkReal (tm : TermManager) (num : Int) (den : Int := 1) : Term :=
+    tm.mkRealFromString s!"{num}/{den}" |> Error.unwrap!
 
 /-- Create operator of Kind:
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -11,6 +11,7 @@ import cvc5.Init
 import cvc5.Kind
 import cvc5.ProofRule
 import cvc5.SkolemId
+import cvc5.Types
 
 namespace cvc5
 

--- a/cvc5/Types.lean
+++ b/cvc5/Types.lean
@@ -1,0 +1,467 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
+
+namespace cvc5
+
+/--
+The different reasons for returning an "unknown" result.
+-/
+inductive UnknownExplanation where
+  /--
+  Full satisfiability check required (e.g., if only preprocessing was
+  performed).
+  -/
+  | REQUIRES_FULL_CHECK
+  /--
+  Incomplete theory solver. 
+  -/
+  | INCOMPLETE
+  /--
+  Time limit reached. 
+  -/
+  | TIMEOUT
+  /--
+  Resource limit reached. 
+  -/
+  | RESOURCEOUT
+  /--
+  Memory limit reached. 
+  -/
+  | MEMOUT
+  /--
+  Solver was interrupted. 
+  -/
+  | INTERRUPTED
+  /--
+  Unsupported feature encountered. 
+  -/
+  | UNSUPPORTED
+  /--
+  Other reason. 
+  -/
+  | OTHER
+  /--
+  Requires another satisfiability check 
+  -/
+  | REQUIRES_CHECK_AGAIN
+  /--
+  No specific reason given. 
+  -/
+  | UNKNOWN_REASON
+deriving Inhabited, Repr, BEq
+
+namespace UnknownExplanation
+
+/-- Produces a string representation. -/
+@[extern "unknownExplanation_toString"]
+protected opaque toString : UnknownExplanation → String
+
+instance : ToString UnknownExplanation := ⟨UnknownExplanation.toString⟩
+
+/-- Produces a hash. -/
+@[extern "unknownExplanation_hash"]
+protected opaque hash : UnknownExplanation → UInt64
+
+instance : Hashable UnknownExplanation := ⟨UnknownExplanation.hash⟩
+
+end UnknownExplanation
+
+/--
+Rounding modes for floating-point numbers.
+
+For many floating-point operations, infinitely precise results may not be
+representable with the number of available bits. Thus, the results are
+rounded in a certain way to one of the representable floating-point numbers.
+
+\verbatim embed:rst:leading-asterisk
+These rounding modes directly follow the SMT-LIB theory for floating-point
+arithmetic, which in turn is based on IEEE Standard 754 :cite:`IEEE754`.
+The rounding modes are specified in Sections 4.3.1 and 4.3.2 of the IEEE
+Standard 754.
+\endverbatim
+-/
+inductive RoundingMode where
+  /--
+  Round to the nearest even number.
+  
+  If the two nearest floating-point numbers bracketing an unrepresentable
+  infinitely precise result are equally near, the one with an even least
+  significant digit will be delivered.
+  -/
+  | ROUND_NEAREST_TIES_TO_EVEN
+  /--
+  Round towards positive infinity (SMT-LIB: ``+oo``).
+  
+  The result shall be the format's floating-point number (possibly ``+oo``)
+  closest to and no less than the infinitely precise result.
+  -/
+  | ROUND_TOWARD_POSITIVE
+  /--
+  Round towards negative infinity (``-oo``).
+  
+  The result shall be the format's floating-point number (possibly ``-oo``)
+  closest to and no less than the infinitely precise result.
+  -/
+  | ROUND_TOWARD_NEGATIVE
+  /--
+  Round towards zero.
+  
+  The result shall be the format's floating-point number closest to and no
+  greater in magnitude than the infinitely precise result.
+  -/
+  | ROUND_TOWARD_ZERO
+  /--
+  Round to the nearest number away from zero.
+  
+  If the two nearest floating-point numbers bracketing an unrepresentable
+  infinitely precise result are equally near), the one with larger magnitude
+  will be selected.
+  -/
+  | ROUND_NEAREST_TIES_TO_AWAY
+deriving Inhabited, Repr, BEq
+
+namespace RoundingMode
+
+/-- Produces a string representation. -/
+@[extern "roundingMode_toString"]
+protected opaque toString : RoundingMode → String
+
+instance : ToString RoundingMode := ⟨RoundingMode.toString⟩
+
+/-- Produces a hash. -/
+@[extern "roundingMode_hash"]
+protected opaque hash : RoundingMode → UInt64
+
+instance : Hashable RoundingMode := ⟨RoundingMode.hash⟩
+
+end RoundingMode
+
+/--
+Mode for blocking models.
+
+Specifies how models are blocked in Solver::blockModel and
+Solver::blockModelValues.
+-/
+inductive BlockModelsMode where
+  /--
+  Block models based on the SAT skeleton. 
+  -/
+  | LITERALS
+  /--
+  Block models based on the concrete model values for the free variables. 
+  -/
+  | VALUES
+deriving Inhabited, Repr, BEq
+
+namespace BlockModelsMode
+
+/-- Produces a string representation. -/
+@[extern "blockModelsMode_toString"]
+protected opaque toString : BlockModelsMode → String
+
+instance : ToString BlockModelsMode := ⟨BlockModelsMode.toString⟩
+
+/-- Produces a hash. -/
+@[extern "blockModelsMode_hash"]
+protected opaque hash : BlockModelsMode → UInt64
+
+instance : Hashable BlockModelsMode := ⟨BlockModelsMode.hash⟩
+
+end BlockModelsMode
+
+/--
+Types of learned literals.
+
+Specifies categories of literals learned for the method
+Solver::getLearnedLiterals.
+
+Note that a literal may conceptually belong to multiple categories. We
+classify literals based on the first criteria in this list that they meet.
+-/
+inductive LearnedLitType where
+  /--
+  An equality that was turned into a substitution during preprocessing.
+  
+  In particular, literals in this category are of the form (= x t) where
+  x does not occur in t.
+  -/
+  | PREPROCESS_SOLVED
+  /--
+  A top-level literal (unit clause) from the preprocessed set of input
+  formulas.
+  -/
+  | PREPROCESS
+  /--
+  A literal from the preprocessed set of input formulas that does not
+  occur at top-level after preprocessing.
+  
+  Typically), this is the most interesting category of literals to learn.
+  -/
+  | INPUT
+  /--
+  An internal literal that is solvable for an input variable.
+  
+  In particular, literals in this category are of the form (= x t) where
+  x does not occur in t, the preprocessed set of input formulas contains the
+  term x, but not the literal (= x t).
+  
+  Note that solvable literals can be turned into substitutions during
+  preprocessing.
+  -/
+  | SOLVABLE
+  /--
+  An internal literal that can be made into a constant propagation for an
+  input term.
+  
+  In particular, literals in this category are of the form (= t c) where
+  c is a constant, the preprocessed set of input formulas contains the
+  term t, but not the literal (= t c).
+  -/
+  | CONSTANT_PROP
+  /--
+  Any internal literal that does not fall into the above categories. 
+  -/
+  | INTERNAL
+  /--
+  Special case for when produce-learned-literals is not set.  
+  -/
+  | UNKNOWN
+deriving Inhabited, Repr, BEq
+
+namespace LearnedLitType
+
+/-- Produces a string representation. -/
+@[extern "learnedLitType_toString"]
+protected opaque toString : LearnedLitType → String
+
+instance : ToString LearnedLitType := ⟨LearnedLitType.toString⟩
+
+/-- Produces a hash. -/
+@[extern "learnedLitType_hash"]
+protected opaque hash : LearnedLitType → UInt64
+
+instance : Hashable LearnedLitType := ⟨LearnedLitType.hash⟩
+
+end LearnedLitType
+
+/--
+Components to include in a proof.
+-/
+inductive ProofComponent where
+  /--
+  Proofs of G1 ... Gn whose free assumptions are a subset of
+  F1, ... Fm, where:
+  - G1, ... Gn are the preprocessed input formulas,
+  - F1, ... Fm are the input formulas.
+  
+  Note that G1 ... Gn may be arbitrary formulas, not necessarily clauses.
+  -/
+  | RAW_PREPROCESS
+  /--
+  Proofs of Gu1 ... Gun whose free assumptions are Fu1, ... Fum,
+  where:
+  - Gu1, ... Gun are clauses corresponding to input formulas used in the SAT
+  proof,
+  - Fu1, ... Fum is the subset of the input formulas that are used in the SAT
+  proof (i.e. the unsat core).
+  
+  Note that Gu1 ... Gun are clauses that are added to the SAT solver before
+  its main search.
+  
+  Only valid immediately after an unsat response.
+  -/
+  | PREPROCESS
+  /--
+  A proof of false whose free assumptions are Gu1, ... Gun, L1 ... Lk,
+  where:
+  - Gu1, ... Gun, is a set of clauses corresponding to input formulas,
+  - L1, ..., Lk is a set of clauses corresponding to theory lemmas.
+  
+  Only valid immediately after an unsat response.
+  -/
+  | SAT
+  /--
+  Proofs of L1 ... Lk where:
+  - L1, ..., Lk are clauses corresponding to theory lemmas used in the SAT
+  proof.
+  
+  In contrast to proofs given for preprocess, L1 ... Lk are clauses that are
+  added to the SAT solver after its main search.
+  
+  Only valid immediately after an unsat response.
+  -/
+  | THEORY_LEMMAS
+  /--
+  A proof of false whose free assumptions are a subset of the input formulas
+  F1), ... Fm.
+  
+  Only valid immediately after an unsat response.
+  -/
+  | FULL
+deriving Inhabited, Repr, BEq
+
+namespace ProofComponent
+
+/-- Produces a string representation. -/
+@[extern "proofComponent_toString"]
+protected opaque toString : ProofComponent → String
+
+instance : ToString ProofComponent := ⟨ProofComponent.toString⟩
+
+/-- Produces a hash. -/
+@[extern "proofComponent_hash"]
+protected opaque hash : ProofComponent → UInt64
+
+instance : Hashable ProofComponent := ⟨ProofComponent.hash⟩
+
+end ProofComponent
+
+/--
+Proof format used for proof printing.
+-/
+inductive ProofFormat where
+  /--
+  Do not translate proof output. 
+  -/
+  | NONE
+  /--
+  Output DOT proof. 
+  -/
+  | DOT
+  /--
+  Output LFSC proof. 
+  -/
+  | LFSC
+  /--
+  Output Alethe proof. 
+  -/
+  | ALETHE
+  /--
+  Output Cooperating Proof Calculus proof based on Eunoia signatures. 
+  -/
+  | CPC
+  /--
+  Use the proof format mode set in the solver options. 
+  -/
+  | DEFAULT
+deriving Inhabited, Repr, BEq
+
+namespace ProofFormat
+
+/-- Produces a string representation. -/
+@[extern "proofFormat_toString"]
+protected opaque toString : ProofFormat → String
+
+instance : ToString ProofFormat := ⟨ProofFormat.toString⟩
+
+/-- Produces a hash. -/
+@[extern "proofFormat_hash"]
+protected opaque hash : ProofFormat → UInt64
+
+instance : Hashable ProofFormat := ⟨ProofFormat.hash⟩
+
+end ProofFormat
+
+/--
+Find synthesis targets, used as an argument to Solver::findSynth. These
+specify various kinds of terms that can be found by this method.
+-/
+inductive FindSynthTarget where
+  /--
+  Find the next term in the enumeration of the target grammar.
+  -/
+  | ENUM
+  /--
+  Find a pair of terms (t,s) in the target grammar which are equivalent
+  but do not rewrite to the same term in the given rewriter
+  (--sygus-rewrite=MODE). If so, the equality (= t s) is returned by
+  findSynth.
+  
+  This can be used to synthesize rewrite rules. Note if the rewriter is set
+  to none (--sygus-rewrite=none), this indicates a possible rewrite when
+  implementing a rewriter from scratch.
+  -/
+  | REWRITE
+  /--
+  Find a term t in the target grammar which rewrites to a term s that is
+  not equivalent to it. If so, the equality (= t s) is returned by
+  findSynth.
+  
+  This can be used to test the correctness of the given rewriter. Any
+  returned rewrite indicates an unsoundness in the given rewriter.
+  -/
+  | REWRITE_UNSOUND
+  /--
+  Find a rewrite between pairs of terms (t,s) that are matchable with terms
+  in the input assertions where t and s are equivalent but do not rewrite
+  to the same term in the given rewriter (--sygus-rewrite=MODE).
+  
+  This can be used to synthesize rewrite rules that apply to the current
+  problem.
+  -/
+  | REWRITE_INPUT
+  /--
+  Find a query over the given grammar. If the given grammar generates terms
+  that are not Boolean, we consider equalities over terms from the given
+  grammar.
+  
+  The algorithm for determining which queries to generate is configured by
+  --sygus-query-gen=MODE. Queries that are internally solved can be
+  filtered by the option --sygus-query-gen-filter-solved.
+  -/
+  | QUERY
+deriving Inhabited, Repr, BEq
+
+namespace FindSynthTarget
+
+/-- Produces a string representation. -/
+@[extern "findSynthTarget_toString"]
+protected opaque toString : FindSynthTarget → String
+
+instance : ToString FindSynthTarget := ⟨FindSynthTarget.toString⟩
+
+/-- Produces a hash. -/
+@[extern "findSynthTarget_hash"]
+protected opaque hash : FindSynthTarget → UInt64
+
+instance : Hashable FindSynthTarget := ⟨FindSynthTarget.hash⟩
+
+end FindSynthTarget
+
+/--
+The different reasons for returning an "unknown" result.
+-/
+inductive InputLanguage where
+  /--
+  The SMT-LIB version 2.6 language 
+  -/
+  | SMT_LIB_2_6
+  /--
+  The SyGuS version 2.1 language. 
+  -/
+  | SYGUS_2_1
+  /--
+  No language given. 
+  -/
+  | UNKNOWN
+deriving Inhabited, Repr, BEq
+
+namespace InputLanguage
+
+/-- Produces a string representation. -/
+@[extern "inputLanguage_toString"]
+protected opaque toString : InputLanguage → String
+
+instance : ToString InputLanguage := ⟨InputLanguage.toString⟩
+
+/-- Produces a hash. -/
+@[extern "inputLanguage_hash"]
+protected opaque hash : InputLanguage → UInt64
+
+instance : Hashable InputLanguage := ⟨InputLanguage.hash⟩
+
+end InputLanguage

--- a/cvc5Test/Unit/ApiResult.lean
+++ b/cvc5Test/Unit/ApiResult.lean
@@ -1,0 +1,83 @@
+import cvc5Test.Init
+
+/-! # Black box testing of the `Op` type
+
+- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_op_black.cpp>
+-/
+
+namespace cvc5.Test
+
+test![TestApiBlackResult, isNull] tm => do
+  -- lean API does not expose null results
+  assertTrue true
+
+test![TestApiBlackResult, equalHash] tm => do
+  let u := tm.mkUninterpretedSort "u"
+  let x ← Solver.declareFun (m := IO) "x" #[] u
+  let x_eq_x ← x.eq x
+  Solver.assertFormula x_eq_x
+  -- skipping null-result-related checks
+  let res1 ← Solver.checkSat
+  let res2 ← Solver.checkSat
+  Solver.assertFormula (← x_eq_x.not)
+  let res3 ← Solver.checkSat
+  assertEq res1 res2
+  assertNe res1 res3
+  assertNe res2 res3
+  assertEq res1.toString "sat"
+  assertEq res2.toString "sat"
+  assertEq res3.toString "unsat"
+  assertEq res1.hash res2.hash
+  assertNe res1.hash res3.hash
+  assertNe res2.hash res3.hash
+
+test![TestApiBlackResult, isSat] tm => do
+  let u := tm.mkUninterpretedSort "u"
+  let x ← Solver.declareFun (m := IO) "x" #[] u
+  Solver.assertFormula (← x.eq x)
+  let res ← Solver.checkSat
+  assertTrue res.isSat
+  assertFalse res.isUnsat
+  assertFalse res.isUnknown
+  -- not part of the original test
+  let ue := res.getUnknownExplanation
+  assertEq ue .UNKNOWN_REASON
+  assertEq ue.toString "UNKNOWN_REASON"
+  assertEq res.getUnknownExplanation? none
+
+test![TestApiBlackResult, isUnsat] tm => do
+  let u := tm.mkUninterpretedSort "u"
+  let x ← Solver.declareFun (m := IO) "x" #[] u
+  Solver.assertFormula (← (← x.eq x).not)
+  let res ← Solver.checkSat
+  assertFalse res.isSat
+  assertTrue res.isUnsat
+  assertFalse res.isUnknown
+  -- not part of the original test
+  let ue := res.getUnknownExplanation
+  assertEq ue .UNKNOWN_REASON
+  assertEq ue.toString "UNKNOWN_REASON"
+  assertEq res.getUnknownExplanation? none
+
+test![TestApiBlackResult, isUnknown] tm => do
+  Solver.setLogic "QF_NIA"
+  Solver.setOption "incremental" "false"
+  Solver.setOption "solve-real-as-int" "true"
+  let realSort := tm.getRealSort
+  let x ← Solver.declareFun (m := IO) "x" #[] realSort
+  let zero := tm.mkReal 0
+  let one := tm.mkReal 1
+  Solver.assertFormula (← tm.mkTerm .LT #[zero, x])
+  Solver.assertFormula (← tm.mkTerm .LT #[x, one])
+  let res ← Solver.checkSat
+  assertFalse res.isSat
+  assertFalse res.isUnsat
+  assertTrue res.isUnknown
+  let ue := res.getUnknownExplanation
+  assertEq ue .INCOMPLETE
+  assertEq ue.toString "INCOMPLETE"
+  let ue? := res.getUnknownExplanation?
+  assertTrue ue?.isSome
+  if let some ue := ue? then
+    assertEq ue .INCOMPLETE
+    assertEq ue.toString "INCOMPLETE"

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -184,6 +184,11 @@ extern "C" uint8_t result_beq(lean_obj_arg l, lean_obj_arg r)
   return bool_box(*result_unbox(l) == *result_unbox(r));
 }
 
+extern "C" uint64_t result_hash(lean_obj_arg s)
+{
+  return std::hash<Result>()(*result_unbox(s));
+}
+
 extern "C" uint8_t result_isSat(lean_obj_arg r)
 {
   return bool_box(result_unbox(r)->isSat());

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1234,6 +1234,16 @@ extern "C" lean_obj_res termManager_mkIntegerFromString(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
+extern "C" lean_obj_res termManager_mkRealFromString(lean_obj_arg tm,
+                                                        lean_obj_arg val)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(
+      lean_box(0),
+      term_box(new Term(mut_tm_unbox(tm)->mkReal(lean_string_cstr(val)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
 extern "C" lean_obj_res termManager_mkTerm(lean_obj_arg tm,
                                            uint16_t kind,
                                            lean_obj_arg children)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -157,7 +157,8 @@ extern "C" uint64_t skolemId_hash(uint8_t si)
 
 extern "C" lean_obj_res unknownExplanation_toString(uint8_t ue)
 {
-  return lean_mk_string(std::to_string(static_cast<UnknownExplanation>(ue)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<UnknownExplanation>(ue)).c_str());
 }
 
 extern "C" uint64_t unknownExplanation_hash(uint8_t ue)
@@ -177,62 +178,74 @@ extern "C" uint64_t roundingMode_hash(uint8_t rm)
 
 extern "C" lean_obj_res blockModelsMode_toString(uint8_t bmm)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::BlockModelsMode>(bmm)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::BlockModelsMode>(bmm)).c_str());
 }
 
 extern "C" uint64_t blockModelsMode_hash(uint8_t bmm)
 {
-  return std::hash<cvc5::modes::BlockModelsMode>()(static_cast<cvc5::modes::BlockModelsMode>(bmm));
+  return std::hash<cvc5::modes::BlockModelsMode>()(
+      static_cast<cvc5::modes::BlockModelsMode>(bmm));
 }
 
 extern "C" lean_obj_res learnedLitType_toString(uint8_t llt)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::LearnedLitType>(llt)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::LearnedLitType>(llt)).c_str());
 }
 
 extern "C" uint64_t learnedLitType_hash(uint8_t llt)
 {
-  return std::hash<cvc5::modes::LearnedLitType>()(static_cast<cvc5::modes::LearnedLitType>(llt));
+  return std::hash<cvc5::modes::LearnedLitType>()(
+      static_cast<cvc5::modes::LearnedLitType>(llt));
 }
 
 extern "C" lean_obj_res proofComponent_toString(uint8_t pc)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::ProofComponent>(pc)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::ProofComponent>(pc)).c_str());
 }
 
 extern "C" uint64_t proofComponent_hash(uint8_t pc)
 {
-  return std::hash<cvc5::modes::ProofComponent>()(static_cast<cvc5::modes::ProofComponent>(pc));
+  return std::hash<cvc5::modes::ProofComponent>()(
+      static_cast<cvc5::modes::ProofComponent>(pc));
 }
 
 extern "C" lean_obj_res proofFormat_toString(uint8_t pf)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::ProofFormat>(pf)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::ProofFormat>(pf)).c_str());
 }
 
 extern "C" uint64_t proofFormat_hash(uint8_t pf)
 {
-  return std::hash<cvc5::modes::ProofFormat>()(static_cast<cvc5::modes::ProofFormat>(pf));
+  return std::hash<cvc5::modes::ProofFormat>()(
+      static_cast<cvc5::modes::ProofFormat>(pf));
 }
 
 extern "C" lean_obj_res findSynthTarget_toString(uint8_t fst)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::FindSynthTarget>(fst)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::FindSynthTarget>(fst)).c_str());
 }
 
 extern "C" uint64_t findSynthTarget_hash(uint8_t fst)
 {
-  return std::hash<cvc5::modes::FindSynthTarget>()(static_cast<cvc5::modes::FindSynthTarget>(fst));
+  return std::hash<cvc5::modes::FindSynthTarget>()(
+      static_cast<cvc5::modes::FindSynthTarget>(fst));
 }
 
 extern "C" lean_obj_res inputLanguage_toString(uint8_t il)
 {
-  return lean_mk_string(std::to_string(static_cast<cvc5::modes::InputLanguage>(il)).c_str());
+  return lean_mk_string(
+      std::to_string(static_cast<cvc5::modes::InputLanguage>(il)).c_str());
 }
 
 extern "C" uint64_t inputLanguage_hash(uint8_t il)
 {
-  return std::hash<cvc5::modes::InputLanguage>()(static_cast<cvc5::modes::InputLanguage>(il));
+  return std::hash<cvc5::modes::InputLanguage>()(
+      static_cast<cvc5::modes::InputLanguage>(il));
 }
 
 static void result_finalize(void* obj) { delete static_cast<Result*>(obj); }
@@ -837,8 +850,9 @@ extern "C" lean_obj_res term_or(lean_obj_arg t1, lean_obj_arg t2)
 extern "C" lean_obj_res term_xor(lean_obj_arg t1, lean_obj_arg t2)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok(lean_box(0),
-                   term_box(new Term(term_unbox(t1)->xorTerm(*term_unbox(t2)))));
+  return except_ok(
+      lean_box(0),
+      term_box(new Term(term_unbox(t1)->xorTerm(*term_unbox(t2)))));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
@@ -853,16 +867,20 @@ extern "C" lean_obj_res term_eq(lean_obj_arg t1, lean_obj_arg t2)
 extern "C" lean_obj_res term_imp(lean_obj_arg t1, lean_obj_arg t2)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok(lean_box(0),
-                   term_box(new Term(term_unbox(t1)->impTerm(*term_unbox(t2)))));
+  return except_ok(
+      lean_box(0),
+      term_box(new Term(term_unbox(t1)->impTerm(*term_unbox(t2)))));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
-extern "C" lean_obj_res term_ite(lean_obj_arg t1, lean_obj_arg t2, lean_obj_arg t3)
+extern "C" lean_obj_res term_ite(lean_obj_arg t1,
+                                 lean_obj_arg t2,
+                                 lean_obj_arg t3)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(lean_box(0),
-                   term_box(new Term(term_unbox(t1)->iteTerm(*term_unbox(t2), *term_unbox(t3)))));
+                   term_box(new Term(term_unbox(t1)->iteTerm(
+                       *term_unbox(t2), *term_unbox(t3)))));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
@@ -1320,7 +1338,7 @@ extern "C" lean_obj_res termManager_mkIntegerFromString(lean_obj_arg tm,
 }
 
 extern "C" lean_obj_res termManager_mkRealFromString(lean_obj_arg tm,
-                                                        lean_obj_arg val)
+                                                     lean_obj_arg val)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
   return except_ok(
@@ -1363,8 +1381,8 @@ extern "C" lean_obj_res termManager_mkTermOfOp(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
-// This function is not part of the *public* `lean-cvc5` API: it produces a different (fresh) term
-// every time it's called which is really bad for purity.
+// This function is not part of the *public* `lean-cvc5` API: it produces a
+// different (fresh) term every time it's called which is really bad for purity.
 extern "C" lean_obj_res termManager_mkConst(lean_obj_arg tm,
                                             lean_obj_arg sort,
                                             lean_obj_arg symbol)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -109,7 +109,7 @@ extern "C" lean_obj_res kind_toString(uint16_t k)
   return lean_mk_string(std::to_string(static_cast<Kind>(k - 2)).c_str());
 }
 
-extern "C" uint64_t kind_hash(uint8_t k)
+extern "C" uint64_t kind_hash(uint16_t k)
 {
   return std::hash<Kind>()(static_cast<Kind>(k));
 }

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -155,6 +155,86 @@ extern "C" uint64_t skolemId_hash(uint8_t si)
   return std::hash<SkolemId>()(static_cast<SkolemId>(si));
 }
 
+extern "C" lean_obj_res unknownExplanation_toString(uint8_t ue)
+{
+  return lean_mk_string(std::to_string(static_cast<UnknownExplanation>(ue)).c_str());
+}
+
+extern "C" uint64_t unknownExplanation_hash(uint8_t ue)
+{
+  return std::hash<UnknownExplanation>()(static_cast<UnknownExplanation>(ue));
+}
+
+extern "C" lean_obj_res roundingMode_toString(uint8_t rm)
+{
+  return lean_mk_string(std::to_string(static_cast<RoundingMode>(rm)).c_str());
+}
+
+extern "C" uint64_t roundingMode_hash(uint8_t rm)
+{
+  return std::hash<RoundingMode>()(static_cast<RoundingMode>(rm));
+}
+
+extern "C" lean_obj_res blockModelsMode_toString(uint8_t bmm)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::BlockModelsMode>(bmm)).c_str());
+}
+
+extern "C" uint64_t blockModelsMode_hash(uint8_t bmm)
+{
+  return std::hash<cvc5::modes::BlockModelsMode>()(static_cast<cvc5::modes::BlockModelsMode>(bmm));
+}
+
+extern "C" lean_obj_res learnedLitType_toString(uint8_t llt)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::LearnedLitType>(llt)).c_str());
+}
+
+extern "C" uint64_t learnedLitType_hash(uint8_t llt)
+{
+  return std::hash<cvc5::modes::LearnedLitType>()(static_cast<cvc5::modes::LearnedLitType>(llt));
+}
+
+extern "C" lean_obj_res proofComponent_toString(uint8_t pc)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::ProofComponent>(pc)).c_str());
+}
+
+extern "C" uint64_t proofComponent_hash(uint8_t pc)
+{
+  return std::hash<cvc5::modes::ProofComponent>()(static_cast<cvc5::modes::ProofComponent>(pc));
+}
+
+extern "C" lean_obj_res proofFormat_toString(uint8_t pf)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::ProofFormat>(pf)).c_str());
+}
+
+extern "C" uint64_t proofFormat_hash(uint8_t pf)
+{
+  return std::hash<cvc5::modes::ProofFormat>()(static_cast<cvc5::modes::ProofFormat>(pf));
+}
+
+extern "C" lean_obj_res findSynthTarget_toString(uint8_t fst)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::FindSynthTarget>(fst)).c_str());
+}
+
+extern "C" uint64_t findSynthTarget_hash(uint8_t fst)
+{
+  return std::hash<cvc5::modes::FindSynthTarget>()(static_cast<cvc5::modes::FindSynthTarget>(fst));
+}
+
+extern "C" lean_obj_res inputLanguage_toString(uint8_t il)
+{
+  return lean_mk_string(std::to_string(static_cast<cvc5::modes::InputLanguage>(il)).c_str());
+}
+
+extern "C" uint64_t inputLanguage_hash(uint8_t il)
+{
+  return std::hash<cvc5::modes::InputLanguage>()(static_cast<cvc5::modes::InputLanguage>(il));
+}
+
 static void result_finalize(void* obj) { delete static_cast<Result*>(obj); }
 
 static void result_foreach(void*, b_lean_obj_arg)
@@ -202,6 +282,11 @@ extern "C" uint8_t result_isUnsat(lean_obj_arg r)
 extern "C" uint8_t result_isUnknown(lean_obj_arg r)
 {
   return bool_box(result_unbox(r)->isUnknown());
+}
+
+extern "C" uint8_t result_getUnknownExplanation(lean_obj_arg r)
+{
+  return static_cast<int32_t>(result_unbox(r)->getUnknownExplanation());
 }
 
 extern "C" lean_obj_res result_toString(lean_obj_arg r)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -739,6 +739,38 @@ extern "C" lean_obj_res term_or(lean_obj_arg t1, lean_obj_arg t2)
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
+extern "C" lean_obj_res term_xor(lean_obj_arg t1, lean_obj_arg t2)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(lean_box(0),
+                   term_box(new Term(term_unbox(t1)->xorTerm(*term_unbox(t2)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
+extern "C" lean_obj_res term_eq(lean_obj_arg t1, lean_obj_arg t2)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(lean_box(0),
+                   term_box(new Term(term_unbox(t1)->eqTerm(*term_unbox(t2)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
+extern "C" lean_obj_res term_imp(lean_obj_arg t1, lean_obj_arg t2)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(lean_box(0),
+                   term_box(new Term(term_unbox(t1)->impTerm(*term_unbox(t2)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
+extern "C" lean_obj_res term_ite(lean_obj_arg t1, lean_obj_arg t2, lean_obj_arg t3)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(lean_box(0),
+                   term_box(new Term(term_unbox(t1)->iteTerm(*term_unbox(t2), *term_unbox(t3)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
 extern "C" lean_obj_res term_toString(lean_obj_arg t)
 {
   return lean_mk_string(term_unbox(t)->toString().c_str());

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -179,6 +179,11 @@ static inline const Result* result_unbox(b_lean_obj_arg r)
   return static_cast<Result*>(lean_get_external_data(r));
 }
 
+extern "C" uint8_t result_beq(lean_obj_arg l, lean_obj_arg r)
+{
+  return bool_box(*result_unbox(l) == *result_unbox(r));
+}
+
 extern "C" uint8_t result_isSat(lean_obj_arg r)
 {
   return bool_box(result_unbox(r)->isSat());


### PR DESCRIPTION
- `Result` tests from the cvc5 api tests

- `Types.lean`: autogenerated with the same workflow as `Kind.lean` *etc.*

  adds several cvc5 enums related to unknown results explanation and grammar/synthesis

- `Result.getUnknownExplanation`