### PR TITLE
Generate CVC5 enums before build

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -94,7 +94,8 @@ target ffi.o pkg : FilePath := do
       "-I", (pkg.dir / s!"cvc5-{cvc5.target}" / "include").toString,
       "-fPIC"
     ]
-    buildO oFile srcJob flags
+    let compiler := if Platform.isWindows then "cc" else "clang"
+    buildO (compiler := compiler) oFile srcJob flags
 
 input_file libcadical where
   path := s!"cvc5-{cvc5.target}" / "lib" / nameToStaticLib "cadical"

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.20.0-rc5
+leanprover/lean4:v4.20.0


### PR DESCRIPTION
This PR makes it such that upstream users of `lean-cvc5` don't need to run `lean update` before building.

This solution is a bit problematic, however, as it does not capture that the `input_file`s depend on `cvc5Enums`. To avoid a potential race condition, we do all of the work that the `cvc5Enums` job is supposed to do in the "computing build jobs" phase.

The PR also incorporates #8, which somehow seems to have gotten lost after adding Windows support. (This should solve issues like https://github.com/ufmg-smite/lean-smt/issues/173.)