### PR TITLE
feat: lift `Grammar`'s API

### DIFF
--- a/cvc5.lean
+++ b/cvc5.lean
@@ -378,7 +378,9 @@ namespace Grammar
 instance : Nonempty Grammar := GrammarImpl.property
 
 /-- Get a string representation of this command. -/
-protected extern_def toString : Grammar → Env String
+protected extern_def toString : Grammar → String
+
+instance : ToString Grammar := ⟨Grammar.toString⟩
 
 end Grammar
 
@@ -1302,37 +1304,39 @@ namespace Grammar
 extern_def isNull : Grammar → Bool
 
 /-- Physical equality of two grammars. -/
-protected extern_def beq : Grammar → Grammar → Env Bool
+protected extern_def beq : Grammar → Grammar → Bool
+
+instance : BEq Grammar := ⟨Grammar.beq⟩
 
 /-- Hash function for grammar. -/
-protected extern_def hash : Grammar → Env UInt64
+protected extern_def hash : Grammar → UInt64
 
 /-- Add `rule` to the set of rules corresponding to `ntSymbol`.
 
 - `ntSymbol` The non-terminal to which the rule is added.
 - `rule` The rule to add.
 -/
-extern_def addRule : Grammar → (ntSymbol : Term) → (rule : Term) → Env Unit
+extern_def addRule : Grammar → (ntSymbol : Term) → (rule : Term) → Env Grammar
 
 /-- Add `rules` to the set of rules corresponding to `ntSymbol`.
 
 - `ntSymbol` The non-terminal to which the rules are added.
 - `rules` The rules to add.
 -/
-extern_def addRules : Grammar → (ntSymbol : Term) → (rules : Array Term) → Env Unit
+extern_def addRules : Grammar → (ntSymbol : Term) → (rules : Array Term) → Env Grammar
 
 /-- Allow `ntSymbol` to be an arbitrary constant.
 
 - `ntSymbol` The non-terminal allowed to be any constant.
 -/
-extern_def addAnyConstant : Grammar → (ntSymbol : Term) → Env Unit
+extern_def addAnyConstant : Grammar → (ntSymbol : Term) → Env Grammar
 
 /-- Allow `ntSymbol` to be any input variable to corresponding *synth-fun*/*synth-inv* with the same
   sort as `ntSymbol`.
 
 - `ntSymbol` The non-terminal allowed to be any input variable.
 -/
-extern_def addAnyVariable : Grammar → (ntSymbol : Term) → Env Unit
+extern_def addAnyVariable : Grammar → (ntSymbol : Term) → Env Grammar
 
 end Grammar
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -377,7 +377,7 @@ namespace Grammar
 
 instance : Nonempty Grammar := GrammarImpl.property
 
-/-- Get a string representation of this command. -/
+/-- A string representation of this grammar. -/
 protected extern_def toString : Grammar → String
 
 instance : ToString Grammar := ⟨Grammar.toString⟩

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -366,10 +366,10 @@ end Solver
 
 private opaque GrammarImpl : NonemptyType.{0}
 
-/-- Encapsulation of a command.
+/-- A Sygus Grammar.
 
-Grammars are constructed by the `InputParser` and can be invoked on the `Solver` and
-`Grammar`.
+This class can be used to define a context-free grammar of terms. Its interface coincides with the
+definition of grammars in the SyGuS IF 2.1 standard.
 -/
 def Grammar : Type := GrammarImpl.type
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -1311,6 +1311,8 @@ instance : BEq Grammar := ⟨Grammar.beq⟩
 /-- Hash function for grammar. -/
 protected extern_def hash : Grammar → UInt64
 
+instance : Hashable Grammar := ⟨Grammar.hash⟩
+
 /-- Add `rule` to the set of rules corresponding to `ntSymbol`.
 
 - `ntSymbol` The non-terminal to which the rule is added.

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -1627,7 +1627,7 @@ SyGuS v2:
 - `boundVars` The parameters to this function.
 - `sort` The sort of the return value of this function.
 -/
-extern_def synthFunWithoutGrammar :
+private extern_def synthFunWithoutGrammar :
   Solver → (symbol : String) → (boundVars : Array Term) → (sort : cvc5.Sort) → Env Term
 
 /-- Synthesize n-ary function following specified syntactic constraints.
@@ -1643,10 +1643,15 @@ SyGuS v2:
 - `sort` The sort of the return value of this function.
 - `grammar` The syntactic constraints.
 -/
-extern_def synthFunWithGrammar : Solver →
+private extern_def synthFunWithGrammar : Solver →
   (symbol : String) → (boundVars : Array Term) → (sort : cvc5.Sort) → (grammar : Grammar) → Env Term
 
 /-- Synthesizes an n-ary function with optional syntactic constraints to verify.
+
+```smtlib
+(synth-fun <symbol> ( <boundVars>* ) <sort>)
+(synth-fun <symbol> ( <boundVars>* ) <sort> <grammar>)
+```
 
 - `symbol` The name of the function.
 - `boundVars` The parameters to this function.

--- a/cvc5Test/Unit/ApiGrammar.lean
+++ b/cvc5Test/Unit/ApiGrammar.lean
@@ -19,114 +19,116 @@ def sygusSolver (tm : TermManager) : Env Solver := do
   solver.setOption "sygus" "true"
   return solver
 
-test![TestApiBlackGrammar, toString] tm => do
-  let solver ← sygusSolver tm
-  let bool ← tm.getBooleanSort
-  let start ← tm.mkVar bool "start"
-  let grammar ← solver.mkGrammar #[] #[start]
-  assertEq (← grammar.toString) ""
-  grammar.addRule start (← tm.mkBoolean false)
-  assertEq (← grammar.toString) "((start Bool) )((start Bool (false)))"
+-- test![TestApiBlackGrammar, toString] tm => do
+--   let solver ← sygusSolver tm
+--   let bool ← tm.getBooleanSort
+--   let start ← tm.mkVar bool "start"
+--   let mut grammar ← solver.mkGrammar #[] #[start]
+--   assertEq grammar.toString ""
+--   grammar ← grammar.addRule start (← tm.mkBoolean false)
+--   assertEq grammar.toString "((start Bool) )((start Bool (false)))"
 
-test![TestApiBlackGrammar, addRule] tm => do
-  let solver ← sygusSolver tm
-  let bool ← tm.getBooleanSort
-  let nullTerm := Term.null ()
-  let start ← tm.mkVar bool "start"
-  let nts ← tm.mkVar bool "nts"
-  let grammar ← solver.mkGrammar #[] #[start]
-  let fls ← tm.mkBoolean false
+-- test![TestApiBlackGrammar, addRule] tm => do
+--   let solver ← sygusSolver tm
+--   let bool ← tm.getBooleanSort
+--   let nullTerm := Term.null ()
+--   let start ← tm.mkVar bool "start"
+--   let nts ← tm.mkVar bool "nts"
+--   let mut grammar ← solver.mkGrammar #[] #[start]
+--   let fls ← tm.mkBoolean false
 
-  grammar.addRule start fls |> assertOk
+--   grammar ← grammar.addRule start fls |> assertOk
 
-  grammar.addRule nullTerm fls |> assertError
-    "invalid null argument for 'ntSymbol'"
-  grammar.addRule start nullTerm |> assertError
-    "invalid null argument for 'rule'"
-  grammar.addRule nts fls |> assertError
-    "invalid argument 'nts' for 'ntSymbol', \
-    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
-  grammar.addRule start (← tm.mkInteger 0) |> assertError
-    "expected ntSymbol and rule to have the same sort"
+--   grammar.addRule nullTerm fls |> assertError
+--     "invalid null argument for 'ntSymbol'"
+--   grammar.addRule start nullTerm |> assertError
+--     "invalid null argument for 'rule'"
+--   grammar.addRule nts fls |> assertError
+--     "invalid argument 'nts' for 'ntSymbol', \
+--     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+--   grammar.addRule start (← tm.mkInteger 0) |> assertError
+--     "expected ntSymbol and rule to have the same sort"
 
-  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+--   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
-  grammar.addRule start fls |> assertError
-    "Grammar cannot be modified after passing it as an argument to synthFun"
+--   grammar.addRule start fls |> assertError
+--     "Grammar cannot be modified after passing it as an argument to synthFun"
 
-test![TestApiBlackGrammar, addRules] tm => do
-  let solver ← sygusSolver tm
-  let bool ← tm.getBooleanSort
-  let nullTerm := Term.null ()
-  let start ← tm.mkVar bool "start"
-  let nts ← tm.mkVar bool "nts"
-  let grammar ← solver.mkGrammar #[] #[start]
-  let fls ← tm.mkBoolean false
+-- test![TestApiBlackGrammar, addRules] tm => do
+--   let solver ← sygusSolver tm
+--   let bool ← tm.getBooleanSort
+--   let nullTerm := Term.null ()
+--   let start ← tm.mkVar bool "start"
+--   let nts ← tm.mkVar bool "nts"
+--   let mut grammar ← solver.mkGrammar #[] #[start]
+--   let fls ← tm.mkBoolean false
 
-  grammar.addRules start #[fls] |> assertOk
+--   grammar ← grammar.addRules start #[fls] |> assertOk
 
-  grammar.addRules nullTerm #[fls] |> assertError
-    "invalid null argument for 'ntSymbol'"
-  grammar.addRules start #[nullTerm] |> assertError
-    "invalid null term in 'rules' at index 0"
-  grammar.addRules nts #[fls] |> assertError
-    "invalid argument 'nts' for 'ntSymbol', \
-    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
-  grammar.addRules start #[← tm.mkInteger 0] |> assertError
-    "Expected term with sort Bool at index 0 in rules"
+--   grammar.addRules nullTerm #[fls] |> assertError
+--     "invalid null argument for 'ntSymbol'"
+--   grammar.addRules start #[nullTerm] |> assertError
+--     "invalid null term in 'rules' at index 0"
+--   grammar.addRules nts #[fls] |> assertError
+--     "invalid argument 'nts' for 'ntSymbol', \
+--     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+--   grammar.addRules start #[← tm.mkInteger 0] |> assertError
+--     "Expected term with sort Bool at index 0 in rules"
 
-  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+--   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
-  grammar.addRules start #[fls] |> assertError
-    "Grammar cannot be modified after passing it as an argument to synthFun"
+--   grammar.addRules start #[fls] |> assertError
+--     "Grammar cannot be modified after passing it as an argument to synthFun"
 
-test![TestApiBlackGrammar, addAnyConstant] tm => do
-  let solver ← sygusSolver tm
-  let bool ← tm.getBooleanSort
-  let nullTerm := Term.null ()
-  let start ← tm.mkVar bool "start"
-  let nts ← tm.mkVar bool "nts"
-  let grammar ← solver.mkGrammar #[] #[start]
+-- test![TestApiBlackGrammar, addAnyConstant] tm => do
+--   let solver ← sygusSolver tm
+--   let bool ← tm.getBooleanSort
+--   let nullTerm := Term.null ()
+--   let start ← tm.mkVar bool "start"
+--   let nts ← tm.mkVar bool "nts"
+--   let mut grammar ← solver.mkGrammar #[] #[start]
 
-  grammar.addAnyConstant start |> assertOk
-  grammar.addAnyConstant start |> assertOk
+--   grammar ← grammar.addAnyConstant start |> assertOk
+--   grammar ← grammar.addAnyConstant start |> assertOk
 
-  grammar.addAnyConstant nullTerm |> assertError
-    "invalid null argument for 'ntSymbol'"
-  grammar.addAnyConstant nts |> assertError
-    "invalid argument 'nts' for 'ntSymbol', \
-    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+--   grammar.addAnyConstant nullTerm |> assertError
+--     "invalid null argument for 'ntSymbol'"
+--   grammar.addAnyConstant nts |> assertError
+--     "invalid argument 'nts' for 'ntSymbol', \
+--     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
 
-  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+--   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
-  grammar.addAnyConstant start |> assertError
-    "Grammar cannot be modified after passing it as an argument to synthFun"
+--   grammar.addAnyConstant start |> assertError
+--     "Grammar cannot be modified after passing it as an argument to synthFun"
 
-test![TestApiBlackGrammar, addAnyVariable] tm => do
-  let solver ← sygusSolver tm
-  let bool ← tm.getBooleanSort
-  let nullTerm := Term.null ()
-  let x ← tm.mkVar bool "x"
-  let start ← tm.mkVar bool "start"
-  let nts ← tm.mkVar bool "nts"
+-- test![TestApiBlackGrammar, addAnyVariable] tm => do
+--   let solver ← sygusSolver tm
+--   let bool ← tm.getBooleanSort
+--   let nullTerm := Term.null ()
+--   let x ← tm.mkVar bool "x"
+--   let start ← tm.mkVar bool "start"
+--   let nts ← tm.mkVar bool "nts"
 
-  let grammar1 ← solver.mkGrammar #[ x ] #[start]
-  let grammar2 ← solver.mkGrammar #[] #[start]
+--   let mut grammar1 ← solver.mkGrammar #[ x ] #[start]
+--   let mut grammar2 ← solver.mkGrammar #[] #[start]
 
-  grammar1.addAnyVariable start |> assertOk
-  grammar1.addAnyVariable start |> assertOk
-  grammar2.addAnyVariable start |> assertOk
+--   grammar1 ← grammar1.addAnyVariable start |> assertOk
+--   grammar1 ← grammar1.addAnyVariable start |> assertOk
+--   grammar2 ← grammar2.addAnyVariable start |> assertOk
+--   -- silence warning that `grammar2` is unused
+--   let _ := grammar2
 
-  grammar1.addAnyVariable nullTerm |> assertError
-    "invalid null argument for 'ntSymbol'"
-  grammar1.addAnyVariable nts |> assertError
-    "invalid argument 'nts' for 'ntSymbol', \
-    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+--   grammar1.addAnyVariable nullTerm |> assertError
+--     "invalid null argument for 'ntSymbol'"
+--   grammar1.addAnyVariable nts |> assertError
+--     "invalid argument 'nts' for 'ntSymbol', \
+--     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
 
-  solver.synthFun "f" #[] bool grammar1 |> assertOkDiscard
+--   solver.synthFun "f" #[] bool grammar1 |> assertOkDiscard
 
-  grammar1.addAnyVariable start |> assertError
-    "Grammar cannot be modified after passing it as an argument to synthFun"
+--   grammar1.addAnyVariable start |> assertError
+--     "Grammar cannot be modified after passing it as an argument to synthFun"
 
 test![TestApiBlackGrammar, equalHash] tm => do
   let solver ← sygusSolver tm
@@ -136,62 +138,64 @@ test![TestApiBlackGrammar, equalHash] tm => do
   let start2 ← tm.mkVar bool "start"
   let fls ← tm.mkBoolean false
 
-  do
+  let run : Env Unit → Env Unit := id
+
+  run do
     let g1 ← solver.mkGrammar #[] #[start1]
     let g2 ← solver.mkGrammar #[] #[start1]
-    assertEq (← g1.hash) (← g1.hash)
-    assertEq (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    assertEq g1.hash g1.hash
+    assertEq g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
+  run do
     let g1 ← solver.mkGrammar #[] #[start1]
     let g2 ← solver.mkGrammar #[ x ] #[start2]
-    assertNe (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    assertNe g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
+  run do
     let g1 ← solver.mkGrammar #[ x ] #[start1]
     let g2 ← solver.mkGrammar #[ x ] #[start2]
-    assertNe (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    assertNe g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
+  run do
     let g1 ← solver.mkGrammar #[ x ] #[start1]
-    let g2 ← solver.mkGrammar #[ x ] #[start1]
-    g2.addAnyVariable start1
-    assertNe (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    let mut g2 ← solver.mkGrammar #[ x ] #[start1]
+    g2 ← g2.addAnyVariable start1
+    assertNe g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
-    let g1 ← solver.mkGrammar #[ x ] #[start1]
-    let g2 ← solver.mkGrammar #[ x ] #[start1]
+  run do
+    let mut g1 ← solver.mkGrammar #[ x ] #[start1]
+    let mut g2 ← solver.mkGrammar #[ x ] #[start1]
     let rules := #[fls]
-    g1.addRules start1 rules
-    g2.addRules start1 rules
-    assertEq (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    g1 ← g1.addRules start1 rules
+    g2 ← g2.addRules start1 rules
+    assertEq g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
+  run do
     let g1 ← solver.mkGrammar #[ x ] #[start1]
-    let g2 ← solver.mkGrammar #[ x ] #[start1]
+    let mut g2 ← solver.mkGrammar #[ x ] #[start1]
     let rules2 := #[fls]
-    g2.addRules start1 rules2
-    assertNe (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    g2 ← g2.addRules start1 rules2
+    assertNe g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)
 
-  do
-    let g1 ← solver.mkGrammar #[ x ] #[start1]
-    let g2 ← solver.mkGrammar #[ x ] #[start1]
+  run do
+    let mut g1 ← solver.mkGrammar #[ x ] #[start1]
+    let mut g2 ← solver.mkGrammar #[ x ] #[start1]
     let rules1 := #[← tm.mkBoolean true]
     let rules2 := #[fls]
-    g1.addRules start1 rules1
-    g2.addRules start1 rules2
-    assertNe (← g1.hash) (← g2.hash)
-    assertTrue (← g1.beq g1)
-    assertFalse (← g1.beq g2)
+    g1 ← g1.addRules start1 rules1
+    g2 ← g2.addRules start1 rules2
+    assertNe g1.hash g2.hash
+    assertTrue (g1 == g1)
+    assertFalse (g1 == g2)

--- a/cvc5Test/Unit/ApiGrammar.lean
+++ b/cvc5Test/Unit/ApiGrammar.lean
@@ -19,116 +19,116 @@ def sygusSolver (tm : TermManager) : Env Solver := do
   solver.setOption "sygus" "true"
   return solver
 
--- test![TestApiBlackGrammar, toString] tm => do
---   let solver ← sygusSolver tm
---   let bool ← tm.getBooleanSort
---   let start ← tm.mkVar bool "start"
---   let mut grammar ← solver.mkGrammar #[] #[start]
---   assertEq grammar.toString ""
---   grammar ← grammar.addRule start (← tm.mkBoolean false)
---   assertEq grammar.toString "((start Bool) )((start Bool (false)))"
+test![TestApiBlackGrammar, toString] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let start ← tm.mkVar bool "start"
+  let mut grammar ← solver.mkGrammar #[] #[start]
+  assertEq grammar.toString ""
+  grammar ← grammar.addRule start (← tm.mkBoolean false)
+  assertEq grammar.toString "((start Bool) )((start Bool (false)))"
 
--- test![TestApiBlackGrammar, addRule] tm => do
---   let solver ← sygusSolver tm
---   let bool ← tm.getBooleanSort
---   let nullTerm := Term.null ()
---   let start ← tm.mkVar bool "start"
---   let nts ← tm.mkVar bool "nts"
---   let mut grammar ← solver.mkGrammar #[] #[start]
---   let fls ← tm.mkBoolean false
+test![TestApiBlackGrammar, addRule] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let mut grammar ← solver.mkGrammar #[] #[start]
+  let fls ← tm.mkBoolean false
 
---   grammar ← grammar.addRule start fls |> assertOk
+  grammar ← grammar.addRule start fls |> assertOk
 
---   grammar.addRule nullTerm fls |> assertError
---     "invalid null argument for 'ntSymbol'"
---   grammar.addRule start nullTerm |> assertError
---     "invalid null argument for 'rule'"
---   grammar.addRule nts fls |> assertError
---     "invalid argument 'nts' for 'ntSymbol', \
---     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
---   grammar.addRule start (← tm.mkInteger 0) |> assertError
---     "expected ntSymbol and rule to have the same sort"
+  grammar.addRule nullTerm fls |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addRule start nullTerm |> assertError
+    "invalid null argument for 'rule'"
+  grammar.addRule nts fls |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar.addRule start (← tm.mkInteger 0) |> assertError
+    "expected ntSymbol and rule to have the same sort"
 
---   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
---   grammar.addRule start fls |> assertError
---     "Grammar cannot be modified after passing it as an argument to synthFun"
+  grammar.addRule start fls |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
 
--- test![TestApiBlackGrammar, addRules] tm => do
---   let solver ← sygusSolver tm
---   let bool ← tm.getBooleanSort
---   let nullTerm := Term.null ()
---   let start ← tm.mkVar bool "start"
---   let nts ← tm.mkVar bool "nts"
---   let mut grammar ← solver.mkGrammar #[] #[start]
---   let fls ← tm.mkBoolean false
+test![TestApiBlackGrammar, addRules] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let mut grammar ← solver.mkGrammar #[] #[start]
+  let fls ← tm.mkBoolean false
 
---   grammar ← grammar.addRules start #[fls] |> assertOk
+  grammar ← grammar.addRules start #[fls] |> assertOk
 
---   grammar.addRules nullTerm #[fls] |> assertError
---     "invalid null argument for 'ntSymbol'"
---   grammar.addRules start #[nullTerm] |> assertError
---     "invalid null term in 'rules' at index 0"
---   grammar.addRules nts #[fls] |> assertError
---     "invalid argument 'nts' for 'ntSymbol', \
---     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
---   grammar.addRules start #[← tm.mkInteger 0] |> assertError
---     "Expected term with sort Bool at index 0 in rules"
+  grammar.addRules nullTerm #[fls] |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addRules start #[nullTerm] |> assertError
+    "invalid null term in 'rules' at index 0"
+  grammar.addRules nts #[fls] |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar.addRules start #[← tm.mkInteger 0] |> assertError
+    "Expected term with sort Bool at index 0 in rules"
 
---   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
---   grammar.addRules start #[fls] |> assertError
---     "Grammar cannot be modified after passing it as an argument to synthFun"
+  grammar.addRules start #[fls] |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
 
--- test![TestApiBlackGrammar, addAnyConstant] tm => do
---   let solver ← sygusSolver tm
---   let bool ← tm.getBooleanSort
---   let nullTerm := Term.null ()
---   let start ← tm.mkVar bool "start"
---   let nts ← tm.mkVar bool "nts"
---   let mut grammar ← solver.mkGrammar #[] #[start]
+test![TestApiBlackGrammar, addAnyConstant] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let mut grammar ← solver.mkGrammar #[] #[start]
 
---   grammar ← grammar.addAnyConstant start |> assertOk
---   grammar ← grammar.addAnyConstant start |> assertOk
+  grammar ← grammar.addAnyConstant start |> assertOk
+  grammar ← grammar.addAnyConstant start |> assertOk
 
---   grammar.addAnyConstant nullTerm |> assertError
---     "invalid null argument for 'ntSymbol'"
---   grammar.addAnyConstant nts |> assertError
---     "invalid argument 'nts' for 'ntSymbol', \
---     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar.addAnyConstant nullTerm |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addAnyConstant nts |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
 
---   solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
 
---   grammar.addAnyConstant start |> assertError
---     "Grammar cannot be modified after passing it as an argument to synthFun"
+  grammar.addAnyConstant start |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
 
--- test![TestApiBlackGrammar, addAnyVariable] tm => do
---   let solver ← sygusSolver tm
---   let bool ← tm.getBooleanSort
---   let nullTerm := Term.null ()
---   let x ← tm.mkVar bool "x"
---   let start ← tm.mkVar bool "start"
---   let nts ← tm.mkVar bool "nts"
+test![TestApiBlackGrammar, addAnyVariable] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let x ← tm.mkVar bool "x"
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
 
---   let mut grammar1 ← solver.mkGrammar #[ x ] #[start]
---   let mut grammar2 ← solver.mkGrammar #[] #[start]
+  let mut grammar1 ← solver.mkGrammar #[ x ] #[start]
+  let mut grammar2 ← solver.mkGrammar #[] #[start]
 
---   grammar1 ← grammar1.addAnyVariable start |> assertOk
---   grammar1 ← grammar1.addAnyVariable start |> assertOk
---   grammar2 ← grammar2.addAnyVariable start |> assertOk
---   -- silence warning that `grammar2` is unused
---   let _ := grammar2
+  grammar1 ← grammar1.addAnyVariable start |> assertOk
+  grammar1 ← grammar1.addAnyVariable start |> assertOk
+  grammar2 ← grammar2.addAnyVariable start |> assertOk
+  -- silence warning that `grammar2` is unused
+  let _ := grammar2
 
---   grammar1.addAnyVariable nullTerm |> assertError
---     "invalid null argument for 'ntSymbol'"
---   grammar1.addAnyVariable nts |> assertError
---     "invalid argument 'nts' for 'ntSymbol', \
---     expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar1.addAnyVariable nullTerm |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar1.addAnyVariable nts |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
 
---   solver.synthFun "f" #[] bool grammar1 |> assertOkDiscard
+  solver.synthFun "f" #[] bool grammar1 |> assertOkDiscard
 
---   grammar1.addAnyVariable start |> assertError
---     "Grammar cannot be modified after passing it as an argument to synthFun"
+  grammar1.addAnyVariable start |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
 
 test![TestApiBlackGrammar, equalHash] tm => do
   let solver ← sygusSolver tm

--- a/cvc5Test/Unit/ApiGrammar.lean
+++ b/cvc5Test/Unit/ApiGrammar.lean
@@ -1,0 +1,197 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
+
+import cvc5Test.Init
+
+/-! # Black box testing of the `Grammar` type
+
+- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_grammar_black.cpp>
+-/
+
+namespace cvc5.Test
+
+def sygusSolver (tm : TermManager) : Env Solver := do
+  let solver ← Solver.new tm
+  solver.setOption "sygus" "true"
+  return solver
+
+test![TestApiBlackGrammar, toString] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let start ← tm.mkVar bool "start"
+  let grammar ← solver.mkGrammar #[] #[start]
+  assertEq (← grammar.toString) ""
+  grammar.addRule start (← tm.mkBoolean false)
+  assertEq (← grammar.toString) "((start Bool) )((start Bool (false)))"
+
+test![TestApiBlackGrammar, addRule] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let grammar ← solver.mkGrammar #[] #[start]
+  let fls ← tm.mkBoolean false
+
+  grammar.addRule start fls |> assertOk
+
+  grammar.addRule nullTerm fls |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addRule start nullTerm |> assertError
+    "invalid null argument for 'rule'"
+  grammar.addRule nts fls |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar.addRule start (← tm.mkInteger 0) |> assertError
+    "expected ntSymbol and rule to have the same sort"
+
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+
+  grammar.addRule start fls |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
+
+test![TestApiBlackGrammar, addRules] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let grammar ← solver.mkGrammar #[] #[start]
+  let fls ← tm.mkBoolean false
+
+  grammar.addRules start #[fls] |> assertOk
+
+  grammar.addRules nullTerm #[fls] |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addRules start #[nullTerm] |> assertError
+    "invalid null term in 'rules' at index 0"
+  grammar.addRules nts #[fls] |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+  grammar.addRules start #[← tm.mkInteger 0] |> assertError
+    "Expected term with sort Bool at index 0 in rules"
+
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+
+  grammar.addRules start #[fls] |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
+
+test![TestApiBlackGrammar, addAnyConstant] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+  let grammar ← solver.mkGrammar #[] #[start]
+
+  grammar.addAnyConstant start |> assertOk
+  grammar.addAnyConstant start |> assertOk
+
+  grammar.addAnyConstant nullTerm |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar.addAnyConstant nts |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+
+  solver.synthFun "f" #[] bool grammar |> assertOkDiscard
+
+  grammar.addAnyConstant start |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
+
+test![TestApiBlackGrammar, addAnyVariable] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let nullTerm := Term.null ()
+  let x ← tm.mkVar bool "x"
+  let start ← tm.mkVar bool "start"
+  let nts ← tm.mkVar bool "nts"
+
+  let grammar1 ← solver.mkGrammar #[ x ] #[start]
+  let grammar2 ← solver.mkGrammar #[] #[start]
+
+  grammar1.addAnyVariable start |> assertOk
+  grammar1.addAnyVariable start |> assertOk
+  grammar2.addAnyVariable start |> assertOk
+
+  grammar1.addAnyVariable nullTerm |> assertError
+    "invalid null argument for 'ntSymbol'"
+  grammar1.addAnyVariable nts |> assertError
+    "invalid argument 'nts' for 'ntSymbol', \
+    expected ntSymbol to be one of the non-terminal symbols given in the predeclaration"
+
+  solver.synthFun "f" #[] bool grammar1 |> assertOkDiscard
+
+  grammar1.addAnyVariable start |> assertError
+    "Grammar cannot be modified after passing it as an argument to synthFun"
+
+test![TestApiBlackGrammar, equalHash] tm => do
+  let solver ← sygusSolver tm
+  let bool ← tm.getBooleanSort
+  let x ← tm.mkVar bool "x"
+  let start1 ← tm.mkVar bool "start"
+  let start2 ← tm.mkVar bool "start"
+  let fls ← tm.mkBoolean false
+
+  do
+    let g1 ← solver.mkGrammar #[] #[start1]
+    let g2 ← solver.mkGrammar #[] #[start1]
+    assertEq (← g1.hash) (← g1.hash)
+    assertEq (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start2]
+    assertNe (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[ x ] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start2]
+    assertNe (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[ x ] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start1]
+    g2.addAnyVariable start1
+    assertNe (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[ x ] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start1]
+    let rules := #[fls]
+    g1.addRules start1 rules
+    g2.addRules start1 rules
+    assertEq (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[ x ] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start1]
+    let rules2 := #[fls]
+    g2.addRules start1 rules2
+    assertNe (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)
+
+  do
+    let g1 ← solver.mkGrammar #[ x ] #[start1]
+    let g2 ← solver.mkGrammar #[ x ] #[start1]
+    let rules1 := #[← tm.mkBoolean true]
+    let rules2 := #[fls]
+    g1.addRules start1 rules1
+    g2.addRules start1 rules2
+    assertNe (← g1.hash) (← g2.hash)
+    assertTrue (← g1.beq g1)
+    assertFalse (← g1.beq g2)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1666,44 +1666,47 @@ LEAN_EXPORT uint8_t grammar_isNull(lean_obj_arg gram)
   return bool_box(grammar_unbox(gram)->isNull());
 }
 
-LEAN_EXPORT lean_obj_res grammar_toString(lean_obj_arg gram, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res grammar_toString(lean_obj_arg gram)
 {
-  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(lean_mk_string(grammar_unbox(gram)->toString().c_str()), ioWorld);
-  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+  return lean_mk_string(grammar_unbox(gram)->toString().c_str());
 }
 
-LEAN_EXPORT lean_obj_res grammar_hash(lean_obj_arg t, lean_obj_arg ioWorld)
+LEAN_EXPORT uint64_t grammar_hash(lean_obj_arg t)
 {
-  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_uint64(std::hash<Grammar>()(*grammar_unbox(t)), ioWorld);
-  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+  return std::hash<Grammar>()(*grammar_unbox(t));
 }
 
-LEAN_EXPORT lean_obj_res grammar_beq(lean_obj_arg l, lean_obj_arg r, lean_obj_arg ioWorld)
+LEAN_EXPORT uint8_t grammar_beq(lean_obj_arg l, lean_obj_arg r)
 {
-  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_bool(bool_box(*grammar_unbox(l) == *grammar_unbox(r)), ioWorld);
-  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+  return bool_box(*grammar_unbox(l) == *grammar_unbox(r));
 }
 
-LEAN_EXPORT lean_obj_res grammar_addRule(lean_obj_arg grammar,
+/** Clones the input grammar if it has strictly more than one reference to it, otherwise returns
+the input grammar. */
+lean_obj_arg grammar_pseudo_clone(lean_obj_arg grammar){
+  if (lean_is_exclusive(grammar)) return grammar;
+  else return grammar_box(new Grammar(*grammar_unbox(grammar)));
+}
+
+LEAN_EXPORT lean_obj_res grammar_addRule(lean_obj_arg grammarArg,
                                         b_lean_obj_arg ntSymbol,
                                         b_lean_obj_arg rule,
                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
   mut_grammar_unbox(grammar)->addRule(*term_unbox(ntSymbol), *term_unbox(rule));
-  return env_val(mk_unit_unit(), ioWorld);
+  return env_val(grammar, ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammar,
+LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammarArg,
                                         b_lean_obj_arg ntSymbol,
                                         b_lean_obj_arg rules,
                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
   std::vector<Term> ruleVec;
   for (size_t i = 0, n = lean_array_size(rules); i < n; ++i)
   {
@@ -1711,27 +1714,29 @@ LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammar,
         lean_array_get(term_box(new Term()), rules, lean_usize_to_nat(i))));
   }
   mut_grammar_unbox(grammar)->addRules(*term_unbox(ntSymbol), ruleVec);
-  return env_val(mk_unit_unit(), ioWorld);
+  return env_val(grammar, ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res grammar_addAnyConstant(lean_obj_arg grammar,
+LEAN_EXPORT lean_obj_res grammar_addAnyConstant(lean_obj_arg grammarArg,
                                         b_lean_obj_arg ntSymbol,
                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
   mut_grammar_unbox(grammar)->addAnyConstant(*term_unbox(ntSymbol));
-  return env_val(mk_unit_unit(), ioWorld);
+  return env_val(grammar, ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res grammar_addAnyVariable(lean_obj_arg grammar,
+LEAN_EXPORT lean_obj_res grammar_addAnyVariable(lean_obj_arg grammarArg,
                                         b_lean_obj_arg ntSymbol,
                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
   mut_grammar_unbox(grammar)->addAnyVariable(*term_unbox(ntSymbol));
-  return env_val(mk_unit_unit(), ioWorld);
+  return env_val(grammar, ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -57,6 +57,8 @@ lean_obj_res env_pure(lean_obj_arg alpha, lean_obj_arg a, lean_obj_arg ioWorld);
 
 lean_obj_res env_bool(uint8_t b, lean_obj_arg ioWorld);
 
+lean_obj_res env_uint64(uint64_t b, lean_obj_arg ioWorld);
+
 lean_obj_res env_val(lean_obj_arg val, lean_obj_arg ioWorld)
 {
   return env_pure(lean_box(0), val, ioWorld);
@@ -1146,9 +1148,41 @@ static inline Solver* solver_unbox(b_lean_obj_arg s)
   return static_cast<Solver*>(lean_get_external_data(s));
 }
 
+static void grammar_finalize(void* obj)
+{
+  delete static_cast<Grammar*>(obj);
+}
+
+static void grammar_foreach(void*, b_lean_obj_arg)
+{
+  // do nothing since `Command` does not contain nested Lean objects
+}
+
+static lean_external_class* g_grammar_class = nullptr;
+
+static inline lean_obj_res grammar_box(Grammar* grammar)
+{
+  if (g_grammar_class == nullptr)
+  {
+    g_grammar_class =
+        lean_register_external_class(grammar_finalize, grammar_foreach);
+  }
+  return lean_alloc_external(g_grammar_class, grammar);
+}
+
+static inline const Grammar* grammar_unbox(b_lean_obj_arg grammar)
+{
+  return static_cast<Grammar*>(lean_get_external_data(grammar));
+}
+
+static inline Grammar* mut_grammar_unbox(b_lean_obj_arg grammar)
+{
+  return static_cast<Grammar*>(lean_get_external_data(grammar));
+}
+
 static void command_finalize(void* obj)
 {
-  delete static_cast<cvc5::parser::Command*>(obj);
+  delete static_cast<Grammar*>(obj);
 }
 
 static void command_foreach(void*, b_lean_obj_arg)
@@ -1625,6 +1659,82 @@ LEAN_EXPORT lean_obj_res termManager_mkOpOfIndices(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
+// # Grammar imports
+
+LEAN_EXPORT uint8_t grammar_isNull(lean_obj_arg gram)
+{
+  return bool_box(grammar_unbox(gram)->isNull());
+}
+
+LEAN_EXPORT lean_obj_res grammar_toString(lean_obj_arg gram, lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_val(lean_mk_string(grammar_unbox(gram)->toString().c_str()), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_hash(lean_obj_arg t, lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_uint64(std::hash<Grammar>()(*grammar_unbox(t)), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_beq(lean_obj_arg l, lean_obj_arg r, lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_bool(bool_box(*grammar_unbox(l) == *grammar_unbox(r)), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_addRule(lean_obj_arg grammar,
+                                        b_lean_obj_arg ntSymbol,
+                                        b_lean_obj_arg rule,
+                                        lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  mut_grammar_unbox(grammar)->addRule(*term_unbox(ntSymbol), *term_unbox(rule));
+  return env_val(mk_unit_unit(), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammar,
+                                        b_lean_obj_arg ntSymbol,
+                                        b_lean_obj_arg rules,
+                                        lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  std::vector<Term> ruleVec;
+  for (size_t i = 0, n = lean_array_size(rules); i < n; ++i)
+  {
+    ruleVec.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), rules, lean_usize_to_nat(i))));
+  }
+  mut_grammar_unbox(grammar)->addRules(*term_unbox(ntSymbol), ruleVec);
+  return env_val(mk_unit_unit(), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_addAnyConstant(lean_obj_arg grammar,
+                                        b_lean_obj_arg ntSymbol,
+                                        lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  mut_grammar_unbox(grammar)->addAnyConstant(*term_unbox(ntSymbol));
+  return env_val(mk_unit_unit(), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res grammar_addAnyVariable(lean_obj_arg grammar,
+                                        b_lean_obj_arg ntSymbol,
+                                        lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  mut_grammar_unbox(grammar)->addAnyVariable(*term_unbox(ntSymbol));
+  return env_val(mk_unit_unit(), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
 // # Command imports
 
 LEAN_EXPORT uint8_t command_isNull(lean_obj_arg cmd)
@@ -2036,6 +2146,63 @@ LEAN_EXPORT lean_obj_res solver_proofToString(lean_obj_arg solver,
       lean_mk_string(
           solver_unbox(solver)->proofToString(*proof_unbox(proof)).c_str()),
       ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res solver_mkGrammar(lean_obj_arg solver,
+                                          lean_obj_arg boundVars,
+                                          lean_obj_arg ntSymbols,
+                                          lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  std::vector<Term> boundVarVec;
+  for (size_t i = 0, n = lean_array_size(boundVars); i < n; ++i)
+  {
+    boundVarVec.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), boundVars, lean_usize_to_nat(i))));
+  }
+  std::vector<Term> ntSymbolVec;
+  for (size_t i = 0, n = lean_array_size(ntSymbols); i < n; ++i)
+  {
+    ntSymbolVec.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), ntSymbols, lean_usize_to_nat(i))));
+  }
+  return env_val(grammar_box(new Grammar(solver_unbox(solver)->mkGrammar(boundVarVec, ntSymbolVec))), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res solver_synthFunWithoutGrammar(lean_obj_arg solver,
+                                          lean_obj_arg symbol,
+                                          lean_obj_arg boundVars,
+                                          lean_obj_arg sort,
+                                          lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  std::vector<Term> boundVarVec;
+  for (size_t i = 0, n = lean_array_size(boundVars); i < n; ++i)
+  {
+    boundVarVec.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), boundVars, lean_usize_to_nat(i))));
+  }
+  return env_val(term_box(new Term(solver_unbox(solver)->synthFun(lean_string_cstr(symbol), boundVarVec, *sort_unbox(sort)))), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res solver_synthFunWithGrammar(lean_obj_arg solver,
+                                          lean_obj_arg symbol,
+                                          lean_obj_arg boundVars,
+                                          lean_obj_arg sort,
+                                          lean_obj_arg grammar,
+                                          lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  std::vector<Term> boundVarVec;
+  for (size_t i = 0, n = lean_array_size(boundVars); i < n; ++i)
+  {
+    boundVarVec.push_back(*term_unbox(
+        lean_array_get(term_box(new Term()), boundVars, lean_usize_to_nat(i))));
+  }
+  return env_val(term_box(new Term(solver_unbox(solver)->synthFun(lean_string_cstr(symbol), boundVarVec, *sort_unbox(sort), *mut_grammar_unbox(grammar)))), ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1148,10 +1148,7 @@ static inline Solver* solver_unbox(b_lean_obj_arg s)
   return static_cast<Solver*>(lean_get_external_data(s));
 }
 
-static void grammar_finalize(void* obj)
-{
-  delete static_cast<Grammar*>(obj);
-}
+static void grammar_finalize(void* obj) { delete static_cast<Grammar*>(obj); }
 
 static void grammar_foreach(void*, b_lean_obj_arg)
 {
@@ -1180,10 +1177,7 @@ static inline Grammar* mut_grammar_unbox(b_lean_obj_arg grammar)
   return static_cast<Grammar*>(lean_get_external_data(grammar));
 }
 
-static void command_finalize(void* obj)
-{
-  delete static_cast<Grammar*>(obj);
-}
+static void command_finalize(void* obj) { delete static_cast<Grammar*>(obj); }
 
 static void command_foreach(void*, b_lean_obj_arg)
 {
@@ -1681,17 +1675,20 @@ LEAN_EXPORT uint8_t grammar_beq(lean_obj_arg l, lean_obj_arg r)
   return bool_box(*grammar_unbox(l) == *grammar_unbox(r));
 }
 
-/** Clones the input grammar if it has strictly more than one reference to it, otherwise returns
-the input grammar. */
-lean_obj_arg grammar_pseudo_clone(lean_obj_arg grammar){
-  if (lean_is_exclusive(grammar)) return grammar;
-  else return grammar_box(new Grammar(*grammar_unbox(grammar)));
+/** Clones the input grammar if it has strictly more than one reference to it,
+otherwise returns the input grammar. */
+lean_obj_arg grammar_pseudo_clone(lean_obj_arg grammar)
+{
+  if (lean_is_exclusive(grammar))
+    return grammar;
+  else
+    return grammar_box(new Grammar(*grammar_unbox(grammar)));
 }
 
 LEAN_EXPORT lean_obj_res grammar_addRule(lean_obj_arg grammarArg,
-                                        b_lean_obj_arg ntSymbol,
-                                        b_lean_obj_arg rule,
-                                        lean_obj_arg ioWorld)
+                                         b_lean_obj_arg ntSymbol,
+                                         b_lean_obj_arg rule,
+                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
@@ -1701,9 +1698,9 @@ LEAN_EXPORT lean_obj_res grammar_addRule(lean_obj_arg grammarArg,
 }
 
 LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammarArg,
-                                        b_lean_obj_arg ntSymbol,
-                                        b_lean_obj_arg rules,
-                                        lean_obj_arg ioWorld)
+                                          b_lean_obj_arg ntSymbol,
+                                          b_lean_obj_arg rules,
+                                          lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
@@ -1719,8 +1716,8 @@ LEAN_EXPORT lean_obj_res grammar_addRules(lean_obj_arg grammarArg,
 }
 
 LEAN_EXPORT lean_obj_res grammar_addAnyConstant(lean_obj_arg grammarArg,
-                                        b_lean_obj_arg ntSymbol,
-                                        lean_obj_arg ioWorld)
+                                                b_lean_obj_arg ntSymbol,
+                                                lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
@@ -1730,8 +1727,8 @@ LEAN_EXPORT lean_obj_res grammar_addAnyConstant(lean_obj_arg grammarArg,
 }
 
 LEAN_EXPORT lean_obj_res grammar_addAnyVariable(lean_obj_arg grammarArg,
-                                        b_lean_obj_arg ntSymbol,
-                                        lean_obj_arg ioWorld)
+                                                b_lean_obj_arg ntSymbol,
+                                                lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   lean_obj_arg grammar = grammar_pseudo_clone(grammarArg);
@@ -2172,15 +2169,17 @@ LEAN_EXPORT lean_obj_res solver_mkGrammar(lean_obj_arg solver,
     ntSymbolVec.push_back(*term_unbox(
         lean_array_get(term_box(new Term()), ntSymbols, lean_usize_to_nat(i))));
   }
-  return env_val(grammar_box(new Grammar(solver_unbox(solver)->mkGrammar(boundVarVec, ntSymbolVec))), ioWorld);
+  return env_val(grammar_box(new Grammar(solver_unbox(solver)->mkGrammar(
+                     boundVarVec, ntSymbolVec))),
+                 ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
 LEAN_EXPORT lean_obj_res solver_synthFunWithoutGrammar(lean_obj_arg solver,
-                                          lean_obj_arg symbol,
-                                          lean_obj_arg boundVars,
-                                          lean_obj_arg sort,
-                                          lean_obj_arg ioWorld)
+                                                       lean_obj_arg symbol,
+                                                       lean_obj_arg boundVars,
+                                                       lean_obj_arg sort,
+                                                       lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   std::vector<Term> boundVarVec;
@@ -2189,16 +2188,19 @@ LEAN_EXPORT lean_obj_res solver_synthFunWithoutGrammar(lean_obj_arg solver,
     boundVarVec.push_back(*term_unbox(
         lean_array_get(term_box(new Term()), boundVars, lean_usize_to_nat(i))));
   }
-  return env_val(term_box(new Term(solver_unbox(solver)->synthFun(lean_string_cstr(symbol), boundVarVec, *sort_unbox(sort)))), ioWorld);
+  return env_val(
+      term_box(new Term(solver_unbox(solver)->synthFun(
+          lean_string_cstr(symbol), boundVarVec, *sort_unbox(sort)))),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
 LEAN_EXPORT lean_obj_res solver_synthFunWithGrammar(lean_obj_arg solver,
-                                          lean_obj_arg symbol,
-                                          lean_obj_arg boundVars,
-                                          lean_obj_arg sort,
-                                          lean_obj_arg grammar,
-                                          lean_obj_arg ioWorld)
+                                                    lean_obj_arg symbol,
+                                                    lean_obj_arg boundVars,
+                                                    lean_obj_arg sort,
+                                                    lean_obj_arg grammar,
+                                                    lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   std::vector<Term> boundVarVec;
@@ -2207,7 +2209,12 @@ LEAN_EXPORT lean_obj_res solver_synthFunWithGrammar(lean_obj_arg solver,
     boundVarVec.push_back(*term_unbox(
         lean_array_get(term_box(new Term()), boundVars, lean_usize_to_nat(i))));
   }
-  return env_val(term_box(new Term(solver_unbox(solver)->synthFun(lean_string_cstr(symbol), boundVarVec, *sort_unbox(sort), *mut_grammar_unbox(grammar)))), ioWorld);
+  return env_val(term_box(new Term(solver_unbox(solver)->synthFun(
+                     lean_string_cstr(symbol),
+                     boundVarVec,
+                     *sort_unbox(sort),
+                     *mut_grammar_unbox(grammar)))),
+                 ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 


### PR DESCRIPTION
- add `Grammar` and all its functions
- add `Solver.mkGrammar` and `Solver.synthFun` variants
- unit tests for `Grammar`

**NB**: `Grammar` mutations such as `addRule`/`addAnyConstant` produce a *"new"* grammar, to avoid purity concerns with `toString`, `hash`, *etc.* Under the hood we do something similar to arrays: if the grammar is exclusive (*i.e.* has a ref-count of `1`), then we just update the grammar in-place; otherwise we clone the input grammar, modify the clone, and return it.