### PR TITLE
lift the datatype API with tests

### DIFF
--- a/cvc5.lean
+++ b/cvc5.lean
@@ -371,6 +371,84 @@ extern_def new : (tm : TermManager) → Env Solver
 
 end Solver
 
+private opaque DatatypeConstructorDeclImpl : NonemptyType.{0}
+
+/-- A cvc5 datatype constructor declaration.
+
+A datatype constructor declaration is a specification used for creating a datatype constructor.
+-/
+def DatatypeConstructorDecl : Type := DatatypeConstructorDeclImpl.type
+
+namespace DatatypeConstructorDecl
+
+instance : Nonempty DatatypeConstructorDecl := DatatypeConstructorDeclImpl.property
+
+/-- A string representation of this datatype constructor declaration. -/
+protected extern_def toString : DatatypeConstructorDecl → String
+
+instance : ToString DatatypeConstructorDecl := ⟨DatatypeConstructorDecl.toString⟩
+
+end DatatypeConstructorDecl
+
+private opaque DatatypeDeclImpl : NonemptyType.{0}
+
+/-- A cvc5 datatype declaration.
+
+A datatype declaration is not itself a datatype (see `Datatype`), but a specification for creating a
+datatype sort.
+
+The interface for a datatype declaration coincides with the syntax for the SMT-LIB 2.6 command
+`declare-datatype`, or a single datatype within the `declare-datatypes` command.
+
+`Datatype` sorts can be constructed from a `DatatypeDecl` using:
+- `Solver.mkDatatypeSort`
+- `Solver.mkDatatypeSorts`
+-/
+def DatatypeDecl : Type := DatatypeDeclImpl.type
+
+namespace DatatypeDecl
+
+instance : Nonempty DatatypeDecl := DatatypeDeclImpl.property
+
+/-- Get a string representation of this datatype declaration. -/
+protected extern_def toString : DatatypeDecl → String
+
+instance : ToString DatatypeDecl := ⟨DatatypeDecl.toString⟩
+
+end DatatypeDecl
+
+private opaque DatatypeImpl : NonemptyType.{0}
+
+/-- A cvc5 datatype. -/
+def Datatype : Type := DatatypeImpl.type
+
+namespace Datatype
+
+instance : Nonempty Datatype := DatatypeImpl.property
+
+/-- A string representation of this datatype. -/
+protected extern_def toString : Datatype → String
+
+instance : ToString Datatype := ⟨Datatype.toString⟩
+
+end Datatype
+
+private opaque DatatypeConstructorImpl : NonemptyType.{0}
+
+/-- A cvc5 datatype. -/
+def DatatypeConstructor : Type := DatatypeConstructorImpl.type
+
+namespace DatatypeConstructor
+
+instance : Nonempty DatatypeConstructor := DatatypeConstructorImpl.property
+
+/-- A string representation of this datatype. -/
+protected extern_def toString : DatatypeConstructor → String
+
+instance : ToString DatatypeConstructor := ⟨DatatypeConstructor.toString⟩
+
+end DatatypeConstructor
+
 private opaque GrammarImpl : NonemptyType.{0}
 
 /-- A Sygus Grammar.
@@ -596,6 +674,182 @@ private def mkExceptErr {α : Type} : String → Except Error α :=
   .error ∘ Error.error
 
 end ffi_except_constructors
+
+namespace DatatypeConstructorDecl
+
+/-- True if this `DatatypeConstructorDecl` is a null declaration. -/
+extern_def isNull : DatatypeConstructorDecl → Bool
+
+/-- Equality operator. -/
+protected extern_def beq : DatatypeConstructorDecl → DatatypeConstructorDecl → Bool
+
+instance : BEq DatatypeConstructorDecl := ⟨DatatypeConstructorDecl.beq⟩
+
+/-- Hash function for datatype declarations. -/
+protected extern_def hash : DatatypeConstructorDecl → UInt64
+
+instance : Hashable DatatypeConstructorDecl := ⟨DatatypeConstructorDecl.hash⟩
+
+/-- Add datatype selector declaration.
+
+- `name` The name of the datatype selector declaration to add.
+- `sort` The codomain sort of the datatype selector declaration to add.
+-/
+extern_def addSelector :
+  (dtCons : DatatypeConstructorDecl) → (name : String) → (sort : cvc5.Sort) →
+  Env DatatypeConstructorDecl
+
+/-- Add datatype selector declaration whose codomain type is the datatype itself.
+
+- `name` The name of the datatype selector declaration to add.
+-/
+extern_def addSelectorSelf :
+  (dtCons : DatatypeConstructorDecl) → (name : String) → Env DatatypeConstructorDecl
+
+/-- Add datatype selector declaration whose codomain sort is an unresolved datatype with the given
+  name.
+
+- `name` The name of the datatype selector declaration to add.
+- `unresDatatypeName` The name of the unresolved datatype. The codomain of the selector will be the
+  resolved datatype with the given name
+-/
+extern_def addSelectorUnresolved :
+  (dtCons : DatatypeConstructorDecl) → (name : String) → (unresDatatypeName : String) →
+  Env DatatypeConstructorDecl
+
+end DatatypeConstructorDecl
+
+namespace DatatypeDecl
+
+/-- Determine if this datatype declaration is nullary. -/
+extern_def isNull : DatatypeDecl → Bool
+
+/-- Equality operator. -/
+protected extern_def beq : DatatypeDecl → DatatypeDecl → Bool
+
+instance : BEq DatatypeDecl := ⟨DatatypeDecl.beq⟩
+
+/-- Hash function for datatype declarations. -/
+protected extern_def hash : DatatypeDecl → UInt64
+
+instance : Hashable DatatypeDecl := ⟨DatatypeDecl.hash⟩
+
+/-- Get the number of constructors for this datatype declaration. -/
+extern_def getNumConstructors : (dtDecl : DatatypeDecl) → Nat
+
+/-- Determine if this datatype declaration is parametric.
+
+**Warning**: this function is experimental and may change in future versions.
+-/
+extern_def isParametric : (dtDecl : DatatypeDecl) → Bool
+
+/-- Get the name of this datatype declaration. -/
+extern_def getName : (dtDecl : DatatypeDecl) → String
+
+/-- Determine if this datatype declaration is resolved (has already been used to declare a
+datatype).
+-/
+extern_def isResolved : (dtDecl : DatatypeDecl) → Env Bool
+
+/-- Add datatype constructor declaration.
+
+- `ctor` The datatype constructor declaration to add.
+-/
+extern_def addConstructor :
+  (dtDecl : DatatypeDecl) → (ctor : DatatypeConstructorDecl) → Env DatatypeDecl
+
+end DatatypeDecl
+
+namespace DatatypeConstructor
+
+/-- The null datatype. -/
+extern_def null : Unit → DatatypeConstructor
+
+instance : Inhabited DatatypeConstructor := ⟨null ()⟩
+
+/-- True if this datatype is a null object. -/
+extern_def isNull : DatatypeConstructor → Bool
+
+/-- Equality operator. -/
+protected extern_def beq : DatatypeConstructor → DatatypeConstructor → Bool
+
+instance : BEq DatatypeConstructor := ⟨DatatypeConstructor.beq⟩
+
+/-- Hash function for datatypes. -/
+protected extern_def hash : DatatypeConstructor → UInt64
+
+instance : Hashable DatatypeConstructor := ⟨DatatypeConstructor.hash⟩
+
+/-- Get the constructor term of this datatype constructor.
+
+Datatype constructors are a special class of function-like terms whose sort is datatype constructor
+(`Sort.isDatatypeConstructor`). All datatype constructors, including nullary ones, should be used as
+the first argument to terms whose kind is `Kind.APPLY_CONSTRUCTOR`. For example, the nil list can
+be constructor by `tm.mkTerm Kind.APPLY_CONSTRUCTOR #[t]`, where `tm` is a `TermManager` and `t` is
+the term returned by this function.
+
+This function should not be used for parametric datatypes. Instead, use the function
+`DatatypeConstructor.getInstantiatedTerm`.
+-/
+extern_def getTerm : DatatypeConstructor → Term
+
+end DatatypeConstructor
+
+namespace Datatype
+
+/-- The null datatype. -/
+extern_def null : Unit → Datatype
+
+instance : Inhabited Datatype := ⟨null ()⟩
+
+/-- True if this datatype is a null object. -/
+extern_def isNull : Datatype → Bool
+
+/-- Equality operator. -/
+protected extern_def beq : Datatype → Datatype → Bool
+
+instance : BEq Datatype := ⟨Datatype.beq⟩
+
+/-- Hash function for datatypes. -/
+protected extern_def hash : Datatype → UInt64
+
+instance : Hashable Datatype := ⟨Datatype.hash⟩
+
+/-- Determine if this datatype is parametric.
+
+**Warning**: this function is experimental and may change in future versions.
+-/
+extern_def isParametric : Datatype → Bool
+
+/-- Determine if this datatype corresponds to a co-datatype. -/
+extern_def isCodatatype : Datatype → Bool
+
+/-- Get the name of this datatype. -/
+extern_def getName : Datatype → String
+
+/-- Get the number of constructors of this datatype. -/
+extern_def getNumConstructors : Datatype → Nat
+
+/-- Get the datatype constructor with the given name.
+
+This is a linear search through the constructors, so in case of multiple, similarly-named
+constructors, the first is returned.
+
+- `name` The name of the datatype constructor.
+-/
+extern_def!? getConstructor : Datatype → (name : String) → Except Error DatatypeConstructor
+
+/-- Get the datatype constructor at a given index.
+
+- `idx` The index of the datatype constructor to return.
+-/
+extern_def getConstructorAt :
+  (dt : Datatype) → (idx : Fin dt.getNumConstructors) → DatatypeConstructor
+
+instance : GetElem Datatype Nat DatatypeConstructor fun dt idx => idx < dt.getNumConstructors where
+  getElem dt idx h := dt.getConstructorAt ⟨idx, h⟩
+
+end Datatype
 
 end cvc5
 
@@ -823,6 +1077,9 @@ extern_def!? getNullableElementSort : cvc5.Sort → Except Error cvc5.Sort
 
 /-- Get the associated uninterpreted sort constructor of an instantiated uninterpreted sort. -/
 extern_def!? getUninterpretedSortConstructor : cvc5.Sort → Except Error cvc5.Sort
+
+/-- Get the underlying datatype of a datatype sort. -/
+extern_def!? getDatatype : cvc5.Sort → Except Error Datatype
 
 /-- Get the sorts used to instantiate the sort parameters of a parametric sort.
 
@@ -1302,6 +1559,27 @@ If `args` is empty, the `Op` simply wraps the `cvc5.Kind`. The `Kind` can be use
 -/
 extern_def mkOpOfIndices : TermManager → (kind : Kind) → (args : Array Nat := #[]) → Env Op
 with mkOp := @mkOpOfIndices
+
+/-- Create a datatype constructor declaration.
+
+- `name` The name of the datatype constructor.
+-/
+extern_def mkDatatypeConstructorDecl : TermManager → (name : String) → Env DatatypeConstructorDecl
+
+/-- Create a datatype declaration.
+
+- `name` The name of the datatype.
+- `params` A list of sort parameters.
+- `isCoDatatype` True if a codatatype is to be constructed.
+-/
+extern_def mkDatatypeDecl : TermManager → (name : String) →
+  (params : Array cvc5.Sort := #[]) → (isCoDatatype : Bool := false) → Env DatatypeDecl
+
+/-- Create a datatype sort.
+
+- `dtypeDecl` The datatype declaration from which the sort is created.
+-/
+extern_def mkDatatypeSort : TermManager → (dtypeDecl : DatatypeDecl) → Env cvc5.Sort
 
 end TermManager
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -441,7 +441,7 @@ end DatatypeSelector
 
 private opaque DatatypeConstructorImpl : NonemptyType.{0}
 
-/-- A cvc5 datatype. -/
+/-- A cvc5 datatype constructor. -/
 def DatatypeConstructor : Type := DatatypeConstructorImpl.type
 
 namespace DatatypeConstructor
@@ -764,6 +764,13 @@ protected extern_def hash : DatatypeDecl → UInt64
 
 instance : Hashable DatatypeDecl := ⟨DatatypeDecl.hash⟩
 
+/-- Add datatype constructor declaration.
+
+- `ctor` The datatype constructor declaration to add.
+-/
+extern_def addConstructor :
+  DatatypeDecl → (ctor : DatatypeConstructorDecl) → Env DatatypeDecl
+
 /-- Get the number of constructors for this datatype declaration. -/
 extern_def getNumConstructors : DatatypeDecl → Nat
 
@@ -780,13 +787,6 @@ extern_def!? getName : DatatypeDecl → Except Error String
 datatype).
 -/
 extern_def isResolved : DatatypeDecl → Env Bool
-
-/-- Add datatype constructor declaration.
-
-- `ctor` The datatype constructor declaration to add.
--/
-extern_def addConstructor :
-  DatatypeDecl → (ctor : DatatypeConstructorDecl) → Env DatatypeDecl
 
 end DatatypeDecl
 
@@ -956,6 +956,47 @@ protected extern_def hash : Datatype → UInt64
 
 instance : Hashable Datatype := ⟨Datatype.hash⟩
 
+/-- Get the datatype constructor with the given name.
+
+This is a linear search through the constructors, so in case of multiple, similarly-named
+constructors, the first is returned.
+
+- `name` The name of the datatype constructor.
+-/
+extern_def getConstructor : Datatype → (name : String) → Env DatatypeConstructor
+
+/-- Get the number of constructors of this datatype. -/
+extern_def getNumConstructors : Datatype → Nat
+
+/-- Get the datatype constructor at a given index.
+
+- `idx` The index of the datatype constructor to return.
+-/
+extern_def getConstructorAt :
+  (dt : Datatype) → (idx : Fin dt.getNumConstructors) → DatatypeConstructor
+
+instance : GetElem Datatype Nat DatatypeConstructor
+  fun dt idx => idx < dt.getNumConstructors
+where
+  getElem dt idx h := dt.getConstructorAt ⟨idx, h⟩
+
+instance : ForIn m Datatype DatatypeConstructor where
+  forIn dt init fold := forIn' [:dt.getNumConstructors] init fun idx h_member acc =>
+    let constructor := dt.getConstructorAt ⟨idx, h_member.upper⟩
+    fold constructor acc
+
+/-- Get the datatype selector with the given name.
+
+This is a linear search through the constructors and their selectors, so in case of multiple,
+similarly-named selectors, the first is returned.
+
+- `name` The name of the datatype selector.
+-/
+extern_def getSelector : Datatype → (name : String) → Env DatatypeSelector
+
+/-- Get the name of this datatype. -/
+extern_def!? getName : Datatype → Except Error String
+
 /-- Get the parameters of this datatype, if it is parametric.
 
 Asserts that this datatype is parametric.
@@ -991,47 +1032,6 @@ If this datatype is not a codatatype, this returns false if thre are no values o
 that are of finite size.
 -/
 extern_def isWellFounded : Datatype → Bool
-
-/-- Get the name of this datatype. -/
-extern_def!? getName : Datatype → Except Error String
-
-/-- Get the number of constructors of this datatype. -/
-extern_def getNumConstructors : Datatype → Nat
-
-/-- Get the datatype constructor with the given name.
-
-This is a linear search through the constructors, so in case of multiple, similarly-named
-constructors, the first is returned.
-
-- `name` The name of the datatype constructor.
--/
-extern_def getConstructor : Datatype → (name : String) → Env DatatypeConstructor
-
-/-- Get the datatype constructor at a given index.
-
-- `idx` The index of the datatype constructor to return.
--/
-extern_def getConstructorAt :
-  (dt : Datatype) → (idx : Fin dt.getNumConstructors) → DatatypeConstructor
-
-instance : GetElem Datatype Nat DatatypeConstructor
-  fun dt idx => idx < dt.getNumConstructors
-where
-  getElem dt idx h := dt.getConstructorAt ⟨idx, h⟩
-
-instance : ForIn m Datatype DatatypeConstructor where
-  forIn dt init fold := forIn' [:dt.getNumConstructors] init fun idx h_member acc =>
-    let constructor := dt.getConstructorAt ⟨idx, h_member.upper⟩
-    fold constructor acc
-
-/-- Get the datatype selector with the given name.
-
-This is a linear search through the constructors and their selectors, so in case of multiple,
-similarly-named selectors, the first is returned.
-
-- `name` The name of the datatype selector.
--/
-extern_def getSelector : Datatype → (name : String) → Env DatatypeSelector
 
 end Datatype
 

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -869,6 +869,37 @@ This function should not be used for parametric datatypes. Instead, use the func
 -/
 extern_def getTerm : DatatypeConstructor → Env Term
 
+/-- Get the constructor term of this datatype constructor whose return type is `retSort`.
+
+This function is intended to be used on constructors of parametric datatypes and can be seen as
+returning the constructor term that has been explicitly cast to the given sort.
+
+This function is required for constructors of parametric datatypes whose return type cannot be
+determined by type inference. For example, given:
+
+```smtlib
+(declare-datatype List (par (T) ((nil) (cons (head T) (tail (List T))))))
+```
+
+The type of nil terms must be provided by the user. In SMT version 2.6, this is done via the syntax
+for qualified identifiers:
+
+```smtlib
+(as nil (List Int))
+```
+
+This function is equivalent of applying the above, where this DatatypeConstructor is the one
+corresponding to `nil`, and `retSort` is `(List Int)`.
+
+The returned constructor term `t` is used to construct the above (nullary) application of `nil` with
+`TermManager::mkTerm(Kind::APPLY_CONSTRUCTOR, {t})`.
+
+**Warning**: this function is experimental and may change in future versions.
+
+- `retSort` The desired return sort of the constructor.
+-/
+extern_def getInstantiatedTerm : DatatypeConstructor → (retSort : cvc5.Sort) → Env Term
+
 /-- Get the tester term of this datatype constructor.
 
 Similar to constructors, testers are a class of function-like terms of tester sort
@@ -952,7 +983,7 @@ extern_def isTuple : Datatype → Bool
 extern_def isRecord : Datatype → Bool
 
 /-- Determine if this datatype is finite. -/
-extern_def isFinite : Datatype → Bool
+extern_def isFinite : Datatype → Except Error Bool
 
 /-- Determine if this datatype is well-founded.
 

--- a/cvc5Test/Unit/ApiDatatype.lean
+++ b/cvc5Test/Unit/ApiDatatype.lean
@@ -17,18 +17,18 @@ namespace cvc5.Test
 test![TestApiBlackDatatype, mkDatatypeSort] tm => do
   let int ← tm.getIntegerSort
   let mut dtSpec ← tm.mkDatatypeDecl "list"
-  let mut cons ← tm.mkDatatypeConstructorDecl "cons"
-  cons ← cons.addSelector "head" int
-  dtSpec ← dtSpec.addConstructor cons
-  let nil ← tm.mkDatatypeConstructorDecl "nil"
-  dtSpec ← dtSpec.addConstructor nil
+  let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+  consSpec ← consSpec.addSelector "head" int
+  dtSpec ← dtSpec.addConstructor consSpec
+  let nilSpec ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec ← dtSpec.addConstructor nilSpec
   let listSort ← tm.mkDatatypeSort dtSpec
   let d ← listSort.getDatatype
   let consLen := d.getNumConstructors
   if h : consLen = 2 then
-    let consConstr := d[0]
+    let consCtor := d[0]
     let nilConstr := d[1]
-    assertOkDiscard consConstr.getTerm
+    assertOkDiscard consCtor.getTerm
     assertOkDiscard nilConstr.getTerm
   else println! "unexpected number of constructors: {d.getNumConstructors}"
 
@@ -90,55 +90,55 @@ test![TestApiBlackDatatype, isNull] tm => do
 test![TestApiBlackDatatype, equalHash] tm => do
   let int ← tm.getIntegerSort
 
-  let mut dtSpec1 ← tm.mkDatatypeDecl "list"
-  let mut cons1 ← tm.mkDatatypeConstructorDecl "cons"
-  cons1 ← cons1.addSelector "head" int
-  dtSpec1 ← dtSpec1.addConstructor cons1
-  let nil1 ← tm.mkDatatypeConstructorDecl "nil"
-  dtSpec1 ← dtSpec1.addConstructor nil1
-  let listSort1 ← tm.mkDatatypeSort dtSpec1
-  let list1 ← listSort1.getDatatype
-  let consConstr1 := list1[0]!
-  let nilConstr1 := list1[1]!
-  let head1 ← consConstr1.getSelector "head"
+  let mut dt1Spec ← tm.mkDatatypeDecl "list"
+  let mut cons1Spec ← tm.mkDatatypeConstructorDecl "cons"
+  cons1Spec ← cons1Spec.addSelector "head" int
+  dt1Spec ← dt1Spec.addConstructor cons1Spec
+  let nil1Spec ← tm.mkDatatypeConstructorDecl "nil"
+  dt1Spec ← dt1Spec.addConstructor nil1Spec
+  let list1Sort ← tm.mkDatatypeSort dt1Spec
+  let list1 ← list1Sort.getDatatype
+  let cons1Ctor := list1[0]!
+  let nil1Ctor := list1[1]!
+  let head1 ← cons1Ctor.getSelector "head"
 
-  let mut dtSpec2 ← tm.mkDatatypeDecl "list"
-  let mut cons2 ← tm.mkDatatypeConstructorDecl "cons"
-  cons2 ← cons2.addSelector "head" int
-  dtSpec2 ← dtSpec2.addConstructor cons2
-  let nil2 ← tm.mkDatatypeConstructorDecl "nil"
-  dtSpec2 ← dtSpec2.addConstructor nil2
-  let listSort2 ← tm.mkDatatypeSort dtSpec2
-  let list2 ← listSort2.getDatatype
-  let consConstr2 := list2[0]!
-  let nilConstr2 := list2[1]!
-  let head2 ← consConstr2.getSelector "head"
+  let mut dt2Spec ← tm.mkDatatypeDecl "list"
+  let mut cons2Spec ← tm.mkDatatypeConstructorDecl "cons"
+  cons2Spec ← cons2Spec.addSelector "head" int
+  dt2Spec ← dt2Spec.addConstructor cons2Spec
+  let nil2Spec ← tm.mkDatatypeConstructorDecl "nil"
+  dt2Spec ← dt2Spec.addConstructor nil2Spec
+  let list2Sort ← tm.mkDatatypeSort dt2Spec
+  let list2 ← list2Sort.getDatatype
+  let cons2Ctor := list2[0]!
+  let nil2Ctor := list2[1]!
+  let head2 ← cons2Ctor.getSelector "head"
 
-  assertEq dtSpec1 dtSpec1
-  assertNe dtSpec1 dtSpec2
-  assertEq cons1 cons1
-  assertNe cons1 cons2
-  assertEq nil1 nil1
-  assertNe nil1 nil2
-  assertEq consConstr1 consConstr1
-  assertNe consConstr1 consConstr2
-  assertEq nilConstr1 nilConstr1
-  assertNe nilConstr1 nilConstr2
+  assertEq dt1Spec dt1Spec
+  assertNe dt1Spec dt2Spec
+  assertEq cons1Spec cons1Spec
+  assertNe cons1Spec cons2Spec
+  assertEq nil1Spec nil1Spec
+  assertNe nil1Spec nil2Spec
+  assertEq cons1Ctor cons1Ctor
+  assertNe cons1Ctor cons2Ctor
+  assertEq nil1Ctor nil1Ctor
+  assertNe nil1Ctor nil2Ctor
   assertEq head1 head1
   assertNe head1 head2
   assertEq list1 list1
   assertNe list1 list2
 
-  assertEq dtSpec1.hash dtSpec1.hash
-  assertEq dtSpec1.hash dtSpec2.hash
-  assertEq cons1.hash cons1.hash
-  assertEq cons1.hash cons2.hash
-  assertEq nil1.hash nil1.hash
-  assertEq nil1.hash nil2.hash
-  assertEq consConstr1.hash consConstr1.hash
-  assertEq consConstr1.hash consConstr2.hash
-  assertEq nilConstr1.hash nilConstr1.hash
-  assertEq nilConstr1.hash nilConstr2.hash
+  assertEq dt1Spec.hash dt1Spec.hash
+  assertEq dt1Spec.hash dt2Spec.hash
+  assertEq cons1Spec.hash cons1Spec.hash
+  assertEq cons1Spec.hash cons2Spec.hash
+  assertEq nil1Spec.hash nil1Spec.hash
+  assertEq nil1Spec.hash nil2Spec.hash
+  assertEq cons1Ctor.hash cons1Ctor.hash
+  assertEq cons1Ctor.hash cons2Ctor.hash
+  assertEq nil1Ctor.hash nil1Ctor.hash
+  assertEq nil1Ctor.hash nil2Ctor.hash
   assertEq head1.hash head1.hash
   assertEq head1.hash head2.hash
   assertEq list1.hash list1.hash
@@ -193,7 +193,7 @@ test![TestApiBlackDatatype, mkDatatypeSorts] tm => do
   for h : idx in [:dtSorts.size] do
     let sort := dtSorts[idx]
     assertTrue sort.isDatatype
-    assertFalse sort.getDatatype!.isFinite
+    assertFalse <| ← assertOk sort.getDatatype!.isFinite
     assertEq sort.getDatatype!.getName! dtSpecs[idx]!.getName!
 
   -- verify the resolution was correct
@@ -244,7 +244,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   for h : idx in [:dtSorts.size] do
     let sort := dtSorts[idx]
     assertTrue sort.isDatatype
-    assertFalse sort.getDatatype!.isFinite
+    assertFalse <| ← assertOk sort.getDatatype!.isFinite
     assertEq sort.getDatatype!.getName! dtSpecs[idx]!.getName!
 
   -- verify the resolution was correct
@@ -277,7 +277,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   assertFalse dt.isCodatatype
   assertFalse dt.isTuple
   assertFalse dt.isRecord
-  assertFalse dt.isFinite
+  assertFalse <| ← assertOk dt.isFinite
   assertTrue dt.isWellFounded
   -- get constructor
   let dcons := dt[0]!
@@ -295,7 +295,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   let dtSortEnum ← tm.mkDatatypeSort dtSpecEnum
   let dtEnum := dtSortEnum.getDatatype!
   assertFalse dtEnum.isTuple
-  assertTrue dtEnum.isFinite
+  assertTrue <| ← assertOk dtEnum.isFinite
 
   -- create codatatype
   let mut dtSpecStream ← tm.mkDatatypeDecl "stream" (isCoDatatype := true)
@@ -306,7 +306,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   let dtSortStream ← tm.mkDatatypeSort dtSpecStream
   let dtStream := dtSortStream.getDatatype!
   assertTrue dtStream.isCodatatype
-  assertFalse dtStream.isFinite
+  assertFalse <| ← assertOk dtStream.isFinite
   -- codatatypes may be well-founded
   assertTrue dtStream.isWellFounded
 
@@ -315,7 +315,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   let dtTuple := tupSort.getDatatype!
   assertTrue dtTuple.isTuple
   assertFalse dtTuple.isRecord
-  assertTrue dtTuple.isFinite
+  assertTrue <| ← assertOk dtTuple.isFinite
   assertTrue dtTuple.isWellFounded
 
   -- create record
@@ -325,7 +325,7 @@ test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
   let dtRecord := recSort.getDatatype!
   assertFalse dtRecord.isTuple
   assertTrue dtRecord.isRecord
-  assertFalse dtRecord.isFinite
+  assertFalse <| ← assertOk dtRecord.isFinite
   assertTrue dtRecord.isWellFounded
 
 test![TestApiBlackDatatype, datatypeNames] tm => do
@@ -370,3 +370,259 @@ test![TestApiBlackDatatype, datatypeNames] tm => do
   -- possible to construct null datatype declarations if not using solver
   DatatypeDecl.null () |>.getName |> assertError
     "invalid call to 'std::string cvc5::DatatypeDecl::getName() const', expected non-null object"
+
+test![TestApiBlackDatatype, parametricDatatype] tm => do
+  let int ← tm.getIntegerSort
+  let real ← tm.getRealSort
+
+  let t1 ← tm.mkParamSort "T1"
+  let t2 ← tm.mkParamSort "T2"
+  let types := #[t1, t2]
+  let mut pairSpec ← tm.mkDatatypeDecl "pair" types
+
+  let mut mkPairSpec ← tm.mkDatatypeConstructorDecl "mk-pair"
+  mkPairSpec ← mkPairSpec.addSelector "first" t1
+  mkPairSpec ← mkPairSpec.addSelector "second" t2
+  pairSpec ← pairSpec.addConstructor mkPairSpec
+
+  let pairSort ← tm.mkDatatypeSort pairSpec
+
+  assertTrue pairSort.getDatatype!.isParametric
+  let dParams ← pairSort.getDatatype!.getParameters
+  assertTrue (dParams[0]! == t1)
+  assertTrue (dParams[1]! == t2)
+
+  let pairIntInt ← pairSort.instantiate #[int, int]
+  let pairRealReal ← pairSort.instantiate #[real, real]
+  let pairRealInt ← pairSort.instantiate #[real, int]
+  let pairIntReal ← pairSort.instantiate #[int, real]
+
+  assertNe pairIntInt pairRealReal
+  assertNe pairIntReal pairRealReal
+  assertNe pairRealInt pairRealReal
+  assertNe pairIntInt pairIntReal
+  assertNe pairIntInt pairRealInt
+  assertNe pairIntReal pairRealInt
+
+test![TestApiBlackDatatype, isFinite] tm => do
+  let bool ← tm.getBooleanSort
+  let mut dtDecl ← tm.mkDatatypeDecl "dt" #[]
+  let mut ctorDecl ← tm.mkDatatypeConstructorDecl "cons"
+  ctorDecl ← ctorDecl.addSelector "sel" bool
+  dtDecl ← dtDecl.addConstructor ctorDecl
+  let dt ← tm.mkDatatypeSort dtDecl
+  assertTrue <| ← assertOk dt.getDatatype!.isFinite
+
+  let p ← tm.mkParamSort "p1"
+  let mut pDtDecl ← tm.mkDatatypeDecl "dt" #[p]
+  let mut pCtorDecl ← tm.mkDatatypeConstructorDecl "cons"
+  pCtorDecl ← pCtorDecl.addSelector "sel" p
+  pDtDecl ← pDtDecl.addConstructor pCtorDecl
+  let pDt ← tm.mkDatatypeSort pDtDecl
+  pDt.getDatatype!.isFinite |> assertError
+    "invalid call to 'isFinite()', expected non-parametric datatype"
+
+test![TestApiBlackDatatype, datatypeSimplyRec] tm => do
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    wList = leaf(data: list),
+    list = cons(car: wList, cdr: list) | nil,
+    ns = elem(ndata: set(wList)) | elemArray(ndata2: array(list, list))
+  END;
+  ```
+  -/
+
+  -- make unresolved types as placeholders
+  let unresWList ← tm.mkUnresolvedDatatypeSort "wList"
+  let unresList ← tm.mkUnresolvedDatatypeSort "list"
+
+  let mut wListSpec ← tm.mkDatatypeDecl "wList"
+  let mut leafSpec ← tm.mkDatatypeConstructorDecl "leaf"
+  leafSpec ← leafSpec.addSelector "data" unresList
+  wListSpec ← wListSpec.addConstructor leafSpec
+
+  let mut listSpec ← tm.mkDatatypeDecl "list"
+  let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+  consSpec ← consSpec.addSelector "car" unresWList
+  consSpec ← consSpec.addSelector "cdr" unresList
+  listSpec ← listSpec.addConstructor consSpec
+  let nilSpec ← tm.mkDatatypeConstructorDecl "nil"
+  listSpec ← listSpec.addConstructor nilSpec
+
+  let mut nsSpec ← tm.mkDatatypeDecl "ns"
+  let mut elemSpec ← tm.mkDatatypeConstructorDecl "elem"
+  elemSpec ← elemSpec.addSelector "nData" (← tm.mkSetSort unresWList)
+  nsSpec ← nsSpec.addConstructor elemSpec
+  let mut elemArraySpec ← tm.mkDatatypeConstructorDecl "elemArray"
+  elemArraySpec ← elemArraySpec.addSelector "nData" (← tm.mkArraySort unresList unresList)
+  nsSpec ← nsSpec.addConstructor elemArraySpec
+
+  let dtDecls := #[wListSpec, listSpec, nsSpec]
+  let dtSorts ← assertOk <| tm.mkDatatypeSorts dtDecls
+  assertEq 3 dtSorts.size
+  assertTrue dtSorts[0]!.getDatatype!.isWellFounded
+  assertTrue dtSorts[1]!.getDatatype!.isWellFounded
+  assertTrue dtSorts[2]!.getDatatype!.isWellFounded
+
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    ns2 = elem2(nData: array(int, ns2)) | nil2
+  END;
+  ```
+  -/
+  let unresNs2 ← tm.mkUnresolvedDatatypeSort "ns2"
+
+  let mut ns2Spec ← tm.mkDatatypeDecl "ns2"
+  let mut elem2Spec ← tm.mkDatatypeConstructorDecl "elem2"
+  let int ← tm.getIntegerSort
+  elem2Spec ← elem2Spec.addSelector "nData" (← tm.mkArraySort int unresNs2)
+  ns2Spec ← ns2Spec.addConstructor elem2Spec
+  let nil2Spec ← tm.mkDatatypeConstructorDecl "nil2"
+  ns2Spec ← ns2Spec.addConstructor nil2Spec
+
+  let dtDecls := #[ns2Spec]
+  -- this is not well-founded due to non-simple recursion
+  let dtSorts ← tm.mkDatatypeSorts dtDecls
+  assertEq 1 dtSorts.size
+  let codom ← dtSorts[0]!.getDatatype![0]![0]!.getCodomainSort
+  assertTrue codom.isArray
+  assertEq codom.getArrayElementSort! dtSorts[0]!
+  assertTrue dtSorts[0]!.getDatatype!.isWellFounded
+
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    list3 = cons3(car: ns3, cdr: list3) | nil3,
+    ns3 = elem3(nData: set(list3))
+  END;
+  ```
+  -/
+  let unresNs3 ← tm.mkUnresolvedDatatypeSort "ns3"
+  let unresList3 ← tm.mkUnresolvedDatatypeSort "list3"
+
+  let mut list3Spec ← tm.mkDatatypeDecl "list3"
+  let mut cons3Spec ← tm.mkDatatypeConstructorDecl "cons3"
+  cons3Spec ← cons3Spec.addSelector "car" unresNs3
+  cons3Spec ← cons3Spec.addSelector "cdr" unresList3
+  list3Spec ← list3Spec.addConstructor cons3Spec
+  let nil3Spec ← tm.mkDatatypeConstructorDecl "nil3"
+  list3Spec ← list3Spec.addConstructor nil3Spec
+
+  let mut ns3Spec ← tm.mkDatatypeDecl "ns3"
+  let mut elem3Spec ← tm.mkDatatypeConstructorDecl "elem3"
+  elem3Spec ← elem3Spec.addSelector "nData" (← tm.mkSetSort unresList3)
+  ns3Spec ← ns3Spec.addConstructor elem3Spec
+
+  let dtDecls := #[list3Spec, ns3Spec]
+
+  -- both are well-founded and have nested recursion
+  let dtSorts ← tm.mkDatatypeSorts dtDecls
+  assertEq 2 dtSorts.size
+  assertTrue dtSorts[0]!.getDatatype!.isWellFounded
+  assertTrue dtSorts[1]!.getDatatype!.isWellFounded
+
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    list4 = cons(car: set(ns4), cdr: list4) | nil,
+    ns4 = elem(nData: list4)
+  END;
+  ```
+  -/
+  let unresNs4 ← tm.mkUnresolvedDatatypeSort "ns4"
+  let unresList4 ← tm.mkUnresolvedDatatypeSort "list4"
+
+  let mut list4Spec ← tm.mkDatatypeDecl "list4"
+  let mut cons4Spec ← tm.mkDatatypeConstructorDecl "cons4"
+  cons4Spec ← cons4Spec.addSelector "car" (← tm.mkSetSort unresNs4)
+  cons4Spec ← cons4Spec.addSelector "cdr" unresList4
+  list4Spec ← list4Spec.addConstructor cons4Spec
+  let nil4Spec ← tm.mkDatatypeConstructorDecl "nil4"
+  list4Spec ← list4Spec.addConstructor nil4Spec
+
+  let mut ns4Spec ← tm.mkDatatypeDecl "ns4"
+  let mut elem4Spec ← tm.mkDatatypeConstructorDecl "elem4"
+  elem4Spec ← elem4Spec.addSelector "nData" unresList4
+  ns4Spec ← ns4Spec.addConstructor elem4Spec
+
+  let dtDecls := #[list4Spec, ns4Spec]
+  let dtSorts ← tm.mkDatatypeSorts dtDecls
+  assertEq 2 dtSorts.size
+  assertTrue dtSorts[0]!.getDatatype!.isWellFounded
+  assertTrue dtSorts[1]!.getDatatype!.isWellFounded
+
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    list5[X] = cons(car: X, cdr: list5[list5[X]]) | nil
+  END;
+  ```
+  -/
+  let unresList5 ← tm.mkUninterpretedSortConstructorSort 1 "list5"
+
+  let xSort ← tm.mkParamSort "X"
+
+  let mut list5Spec ← tm.mkDatatypeDecl "list5 sortParams" #[xSort]
+  let urListX ← unresList5.instantiate #[xSort]
+  let urListListX ← unresList5.instantiate #[urListX]
+
+  let mut cons5Spec ← tm.mkDatatypeConstructorDecl "cons5"
+  cons5Spec ← cons5Spec.addSelector "car" xSort
+  cons5Spec ← cons5Spec.addSelector "cdr" urListListX
+  list5Spec ← list5Spec.addConstructor cons5Spec
+  let nil5Spec ← tm.mkDatatypeConstructorDecl "nil5"
+  list5Spec ← list5Spec.addConstructor nil5Spec
+
+  -- well-founded and has nested recursion
+  let dtSorts ← tm.mkDatatypeSorts #[list5Spec]
+  assertEq 1 dtSorts.size
+  assertTrue dtSorts[0]!.getDatatype!.isWellFounded
+
+test![TestApiBlackDatatype, datatypeSpecializedCons] tm => do
+  /- Create mutual datatypes corresponding to this definition block:
+
+  ```
+  DATATYPE
+    pList[X] = pCons(car: X, cdr: pList[X]) | pNil
+  END;
+  ```
+  -/
+  -- make unresolved types as placeholders
+  let unresList ← tm.mkUninterpretedSortConstructorSort 1 "pList"
+
+  let xSort ← tm.mkParamSort "X"
+  let mut pListSpec ← tm.mkDatatypeDecl "pList" #[xSort]
+
+  let urListX ← unresList.instantiate #[xSort]
+  let mut pConsSpec ← tm.mkDatatypeConstructorDecl "pCons"
+  pConsSpec ← pConsSpec.addSelector "car" xSort
+  pConsSpec ← pConsSpec.addSelector "cdr" urListX
+  pListSpec ← pListSpec.addConstructor pConsSpec
+  let nil5Spec ← tm.mkDatatypeConstructorDecl "pNil"
+  pListSpec ← pListSpec.addConstructor nil5Spec
+
+  let dtSorts ← tm.mkDatatypeSorts #[pListSpec]
+  assertEq 1 dtSorts.size
+  let dt ← dtSorts[0]!.getDatatype
+  let nilCtor := dt[0]!
+
+  let int ← tm.getIntegerSort
+  let listInt ← dtSorts[0]!.instantiate #[int]
+
+  let liParams ← listInt.getDatatype!.getParameters
+  -- the parameter of the datatype is not instantiated
+  assertEq 1 liParams.size
+  assertEq xSort liParams[0]!
+
+  let testConsTerm ← nilCtor.getInstantiatedTerm listInt
+  assertNe testConsTerm (← nilCtor.getTerm)
+  -- error to get the specialized constructor term for `Int`
+  nilCtor.getInstantiatedTerm int |> assertError
+    "cannot get specialized constructor type for non-datatype type Int"

--- a/cvc5Test/Unit/ApiDatatype.lean
+++ b/cvc5Test/Unit/ApiDatatype.lean
@@ -9,7 +9,7 @@ import cvc5Test.Init
 
 /-! # Black box testing of the `Command` type
 
-- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_command_black.cpp>
+- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_datatype_black.cpp>
 -/
 
 namespace cvc5.Test
@@ -28,7 +28,345 @@ test![TestApiBlackDatatype, mkDatatypeSort] tm => do
   if h : consLen = 2 then
     let consConstr := d[0]
     let nilConstr := d[1]
-    let _consConstrTerm := consConstr.getTerm
-    let _nilConstrTerm := nilConstr.getTerm
-  else
-    println! "unexpected number of constructors: {d.getNumConstructors}"
+    assertOkDiscard consConstr.getTerm
+    assertOkDiscard nilConstr.getTerm
+  else println! "unexpected number of constructors: {d.getNumConstructors}"
+
+test![TestApiBlackDatatype, isNull] tm => do
+  let int ← tm.getIntegerSort
+  -- creating empty (null) objects
+  let mut dtSpec := DatatypeDecl.null ()
+  let mut dtConsSpec := DatatypeConstructorDecl.null ()
+  let mut dt := Datatype.null ()
+  let mut dtCons := DatatypeConstructor.null ()
+  let mut dtSel := DatatypeSelector.null ()
+
+  -- verifying that the objects are considered null
+  assertTrue dtSpec.isNull
+  assertTrue dtConsSpec.isNull
+  assertTrue dt.isNull
+  assertTrue dtCons.isNull
+  assertTrue dtSel.isNull
+
+  -- changing the objects to non-null
+  dtSpec ← tm.mkDatatypeDecl "list"
+  dtConsSpec ← tm.mkDatatypeConstructorDecl "cons"
+  dtConsSpec ← dtConsSpec.addSelector "head" int
+  dtSpec ← dtSpec.addConstructor dtConsSpec
+  assertEq dtSpec.getNumConstructors 1
+  assertFalse dtSpec.isParametric
+  let listSort ← tm.mkDatatypeSort dtSpec
+  dt ← listSort.getDatatype
+  if h : dt.getNumConstructors = 1 then
+    dtCons := dt[0]
+    if h' : dtCons.getNumSelectors = 1 then
+      dtSel := dtCons[0]
+    else println! "unexpected number of selectors: {dtCons.getNumSelectors}"
+  else println! "unexpected number of constructors: {dt.getNumConstructors}"
+
+  -- verifying that the new objects are non-null
+  assertFalse dtSpec.isNull
+  assertFalse dtConsSpec.isNull
+  assertFalse dt.isNull
+  assertFalse dtCons.isNull
+  assertFalse dtSel.isNull
+
+  -- testing string representations
+  dtCons.toString |> assertEq "cons(head: Int)"
+  dtSel.toString |> assertEq "head: Int"
+  dtConsSpec.toString |> assertEq "cons(head: Int)"
+  dtSpec.toString.trim |> assertEq "DATATYPE list = \ncons(head: Int) END;"
+  dt.toString.trim |> assertEq "list"
+
+  -- at this point, the original tests checks the constructor iterator over datatypes; the lean API
+  -- is quite different, so there's not much to check besides that it works
+  let mut i := 0
+  for cons in dt do
+    assertFalse cons.isNull
+    let cons' := dt[i]!
+    i := i + 1
+    assertEq cons.toString cons'.toString
+
+test![TestApiBlackDatatype, equalHash] tm => do
+  let int ← tm.getIntegerSort
+
+  let mut dtSpec1 ← tm.mkDatatypeDecl "list"
+  let mut cons1 ← tm.mkDatatypeConstructorDecl "cons"
+  cons1 ← cons1.addSelector "head" int
+  dtSpec1 ← dtSpec1.addConstructor cons1
+  let nil1 ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec1 ← dtSpec1.addConstructor nil1
+  let listSort1 ← tm.mkDatatypeSort dtSpec1
+  let list1 ← listSort1.getDatatype
+  let consConstr1 := list1[0]!
+  let nilConstr1 := list1[1]!
+  let head1 ← consConstr1.getSelector "head"
+
+  let mut dtSpec2 ← tm.mkDatatypeDecl "list"
+  let mut cons2 ← tm.mkDatatypeConstructorDecl "cons"
+  cons2 ← cons2.addSelector "head" int
+  dtSpec2 ← dtSpec2.addConstructor cons2
+  let nil2 ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec2 ← dtSpec2.addConstructor nil2
+  let listSort2 ← tm.mkDatatypeSort dtSpec2
+  let list2 ← listSort2.getDatatype
+  let consConstr2 := list2[0]!
+  let nilConstr2 := list2[1]!
+  let head2 ← consConstr2.getSelector "head"
+
+  assertEq dtSpec1 dtSpec1
+  assertNe dtSpec1 dtSpec2
+  assertEq cons1 cons1
+  assertNe cons1 cons2
+  assertEq nil1 nil1
+  assertNe nil1 nil2
+  assertEq consConstr1 consConstr1
+  assertNe consConstr1 consConstr2
+  assertEq nilConstr1 nilConstr1
+  assertNe nilConstr1 nilConstr2
+  assertEq head1 head1
+  assertNe head1 head2
+  assertEq list1 list1
+  assertNe list1 list2
+
+  assertEq dtSpec1.hash dtSpec1.hash
+  assertEq dtSpec1.hash dtSpec2.hash
+  assertEq cons1.hash cons1.hash
+  assertEq cons1.hash cons2.hash
+  assertEq nil1.hash nil1.hash
+  assertEq nil1.hash nil2.hash
+  assertEq consConstr1.hash consConstr1.hash
+  assertEq consConstr1.hash consConstr2.hash
+  assertEq nilConstr1.hash nilConstr1.hash
+  assertEq nilConstr1.hash nilConstr2.hash
+  assertEq head1.hash head1.hash
+  assertEq head1.hash head2.hash
+  assertEq list1.hash list1.hash
+  assertEq list1.hash list2.hash
+
+  assertEq 0 (DatatypeDecl.null ()).hash
+  assertEq 0 (DatatypeConstructorDecl.null ()).hash
+  assertEq 0 (DatatypeConstructor.null ()).hash
+  assertEq 0 (DatatypeSelector.null ()).hash
+  assertEq 0 (Datatype.null ()).hash
+
+test![TestApiBlackDatatype, mkDatatypeSorts] tm => do
+  /-
+    Create two mutual datatypes corresponding to these definitions:
+
+    ```
+    DATATYPE
+      tree = node(left: tree, right: tree) | leaf(data: list),
+      list = cons(car: tree, cdr: list) | nil
+    END;
+    ```
+  -/
+
+  -- mark unresolved types as placeholders
+  let unresTree ← tm.mkUnresolvedDatatypeSort "tree"
+  let unresList ← tm.mkUnresolvedDatatypeSort "list"
+
+  let treeSpec ← do
+    let mut treeSpec ← tm.mkDatatypeDecl "tree"
+    let mut nodeSpec ← tm.mkDatatypeConstructorDecl "node"
+    nodeSpec ← nodeSpec.addSelector "left" unresTree
+    nodeSpec ← nodeSpec.addSelector "right" unresTree
+    treeSpec ← treeSpec.addConstructor nodeSpec
+
+    let mut leafSpec ← tm.mkDatatypeConstructorDecl "leaf"
+    leafSpec ← leafSpec.addSelector "data" unresList
+    treeSpec.addConstructor leafSpec
+
+  let listSpec ← do
+    let mut listSpec ← tm.mkDatatypeDecl "list"
+    let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+    consSpec ← consSpec.addSelector "car" unresTree
+    consSpec ← consSpec.addSelector "cdr" unresTree
+    listSpec ← listSpec.addConstructor consSpec
+    let mut nilSpec ← tm.mkDatatypeConstructorDecl "nil"
+    listSpec.addConstructor nilSpec
+
+  let dtSpecs := #[treeSpec, listSpec]
+  let dtSorts ← assertOk <| tm.mkDatatypeSorts dtSpecs
+  assertEq dtSpecs.size dtSorts.size
+
+  for h : idx in [:dtSorts.size] do
+    let sort := dtSorts[idx]
+    assertTrue sort.isDatatype
+    assertFalse sort.getDatatype!.isFinite
+    assertEq sort.getDatatype!.getName! dtSpecs[idx]!.getName!
+
+  -- verify the resolution was correct
+  let dtTree := dtSorts[0]!.getDatatype!
+  let dtcTreeNode := dtTree[0]!
+  assertEq dtcTreeNode.getName! "node"
+  let dtsTreeNodeLeft := dtcTreeNode[0]!
+  assertEq dtsTreeNodeLeft.getName! "left"
+  -- argument type should have resolved to be recursive
+  let dtsTreeNodeLeftCodom ← dtsTreeNodeLeft.getCodomainSort
+  assertTrue dtsTreeNodeLeftCodom.isDatatype
+  assertEq dtsTreeNodeLeftCodom dtSorts[0]!
+
+  -- fails due to empty datatype
+  let dtDeclsBad := #[← tm.mkDatatypeDecl "emptyD"]
+  tm.mkDatatypeSorts dtDeclsBad |> assertError "\
+    invalid datatype declaration in 'dtypedecls' at index 0, \
+    expected a datatype declaration with at least one constructor\
+  "
+
+test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
+  -- same as above, without unresolved sorts
+
+  let treeSpec ← do
+    let mut treeSpec ← tm.mkDatatypeDecl "tree"
+    let mut nodeSpec ← tm.mkDatatypeConstructorDecl "node"
+    nodeSpec ← nodeSpec.addSelectorUnresolved "left" "tree"
+    nodeSpec ← nodeSpec.addSelectorUnresolved "right" "tree"
+    treeSpec ← treeSpec.addConstructor nodeSpec
+
+    let mut leafSpec ← tm.mkDatatypeConstructorDecl "leaf"
+    leafSpec ← leafSpec.addSelectorUnresolved "data" "list"
+    treeSpec.addConstructor leafSpec
+
+  let listSpec ← do
+    let mut listSpec ← tm.mkDatatypeDecl "list"
+    let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+    consSpec ← consSpec.addSelectorUnresolved "car" "tree"
+    consSpec ← consSpec.addSelectorUnresolved "cdr" "tree"
+    listSpec ← listSpec.addConstructor consSpec
+    let mut nilSpec ← tm.mkDatatypeConstructorDecl "nil"
+    listSpec.addConstructor nilSpec
+
+  let dtSpecs := #[treeSpec, listSpec]
+  let dtSorts ← assertOk <| tm.mkDatatypeSorts dtSpecs
+  assertEq dtSpecs.size dtSorts.size
+
+  for h : idx in [:dtSorts.size] do
+    let sort := dtSorts[idx]
+    assertTrue sort.isDatatype
+    assertFalse sort.getDatatype!.isFinite
+    assertEq sort.getDatatype!.getName! dtSpecs[idx]!.getName!
+
+  -- verify the resolution was correct
+  let dtTree := dtSorts[0]!.getDatatype!
+  let dtcTreeNode := dtTree[0]!
+  assertEq dtcTreeNode.getName! "node"
+  let dtsTreeNodeLeft := dtcTreeNode[0]!
+  assertEq dtsTreeNodeLeft.getName! "left"
+  -- argument type should have resolved to be recursive
+  let dtsTreeNodeLeftCodom ← dtsTreeNodeLeft.getCodomainSort
+  assertTrue dtsTreeNodeLeftCodom.isDatatype
+  assertEq dtsTreeNodeLeftCodom dtSorts[0]!
+
+test![TestApiBlackDatatype, mkDatatypeSortsSelUnres] tm => do
+  let int ← tm.getIntegerSort
+  let bool ← tm.getBooleanSort
+
+  -- create datatype sort to test
+  let mut dtSpec ← tm.mkDatatypeDecl "list"
+  let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+  consSpec ← consSpec.addSelector "head" int
+  consSpec ← consSpec.addSelectorSelf "tail"
+  let nullSort := cvc5.Sort.null ()
+  consSpec.addSelector "null" nullSort |> assertError "invalid null argument for 'sort'"
+  dtSpec ← dtSpec.addConstructor consSpec
+  let nilSpec ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec ← dtSpec.addConstructor nilSpec
+  let dtSort ← tm.mkDatatypeSort dtSpec
+  let dt ← dtSort.getDatatype
+  assertFalse dt.isCodatatype
+  assertFalse dt.isTuple
+  assertFalse dt.isRecord
+  assertFalse dt.isFinite
+  assertTrue dt.isWellFounded
+  -- get constructor
+  let dcons := dt[0]!
+  let _ ← dcons.getTerm
+  assertEq 2 dcons.getNumSelectors
+
+  -- create datatype sort to test
+  let mut dtSpecEnum ← tm.mkDatatypeDecl "enum"
+  let ca ← tm.mkDatatypeConstructorDecl "A"
+  dtSpecEnum ← dtSpecEnum.addConstructor ca
+  let cb ← tm.mkDatatypeConstructorDecl "B"
+  dtSpecEnum ← dtSpecEnum.addConstructor cb
+  let cc ← tm.mkDatatypeConstructorDecl "C"
+  dtSpecEnum ← dtSpecEnum.addConstructor cc
+  let dtSortEnum ← tm.mkDatatypeSort dtSpecEnum
+  let dtEnum := dtSortEnum.getDatatype!
+  assertFalse dtEnum.isTuple
+  assertTrue dtEnum.isFinite
+
+  -- create codatatype
+  let mut dtSpecStream ← tm.mkDatatypeDecl "stream" (isCoDatatype := true)
+  let mut consStreamSpec ← tm.mkDatatypeConstructorDecl "cons"
+  consStreamSpec ← consStreamSpec.addSelector "head" int
+  consStreamSpec ← consStreamSpec.addSelectorSelf "tail"
+  dtSpecStream ← dtSpecStream.addConstructor consStreamSpec
+  let dtSortStream ← tm.mkDatatypeSort dtSpecStream
+  let dtStream := dtSortStream.getDatatype!
+  assertTrue dtStream.isCodatatype
+  assertFalse dtStream.isFinite
+  -- codatatypes may be well-founded
+  assertTrue dtStream.isWellFounded
+
+  -- create tuple
+  let tupSort ← tm.mkTupleSort #[bool]
+  let dtTuple := tupSort.getDatatype!
+  assertTrue dtTuple.isTuple
+  assertFalse dtTuple.isRecord
+  assertTrue dtTuple.isFinite
+  assertTrue dtTuple.isWellFounded
+
+  -- create record
+  let fields := #[ ("b", bool), ("i", int) ]
+  let recSort ← tm.mkRecordSort fields
+  assertTrue recSort.isDatatype
+  let dtRecord := recSort.getDatatype!
+  assertFalse dtRecord.isTuple
+  assertTrue dtRecord.isRecord
+  assertFalse dtRecord.isFinite
+  assertTrue dtRecord.isWellFounded
+
+test![TestApiBlackDatatype, datatypeNames] tm => do
+  let int ← tm.getIntegerSort
+
+  -- create datatype sort to test
+  let mut dtSpec ← tm.mkDatatypeDecl "list"
+  assertEq "list" dtSpec.getName!
+  let mut consSpec ← tm.mkDatatypeConstructorDecl "cons"
+  consSpec ← consSpec.addSelector "head" int
+  consSpec ← consSpec.addSelectorSelf "tail"
+  dtSpec ← dtSpec.addConstructor consSpec
+  let nil ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec ← dtSpec.addConstructor nil
+  let dtSort ← tm.mkDatatypeSort dtSpec
+  let dt := dtSort.getDatatype!
+  assertError "expected parametric datatype" dt.getParameters
+  assertEq "list" dt.getName!
+  dt.getConstructor "nil" |> assertOkDiscard
+  dt.getConstructor "cons" |> assertOkDiscard
+  dt.getConstructor "head" |> assertError
+    "no constructor head for datatype list exists, among { cons nil }"
+  dt.getConstructor "" |> assertError
+    "no constructor  for datatype list exists, among { cons nil }"
+
+  let dcons := dt[0]!
+  assertEq "cons" dcons.getName!
+  dcons.getSelector "head" |> assertOkDiscard
+  dcons.getSelector "tail" |> assertOkDiscard
+  dcons.getSelector "cons" |> assertError
+    "no selector cons for constructor cons exists among { head tail }"
+
+  -- get selector
+  let dselTail := dcons[1]!
+  assertEq "tail" dselTail.getName!
+  assertEq dtSort (← dselTail.getCodomainSort)
+
+  -- get selector from datatype
+  dt.getSelector "head" |> assertOkDiscard
+  dt.getSelector "cons" |> assertError "no selector cons for datatype list exists"
+
+  -- possible to construct null datatype declarations if not using solver
+  DatatypeDecl.null () |>.getName |> assertError
+    "invalid call to 'std::string cvc5::DatatypeDecl::getName() const', expected non-null object"

--- a/cvc5Test/Unit/ApiDatatype.lean
+++ b/cvc5Test/Unit/ApiDatatype.lean
@@ -1,0 +1,34 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
+
+import cvc5Test.Init
+
+/-! # Black box testing of the `Command` type
+
+- <https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_command_black.cpp>
+-/
+
+namespace cvc5.Test
+
+test![TestApiBlackDatatype, mkDatatypeSort] tm => do
+  let int ← tm.getIntegerSort
+  let mut dtSpec ← tm.mkDatatypeDecl "list"
+  let mut cons ← tm.mkDatatypeConstructorDecl "cons"
+  cons ← cons.addSelector "head" int
+  dtSpec ← dtSpec.addConstructor cons
+  let nil ← tm.mkDatatypeConstructorDecl "nil"
+  dtSpec ← dtSpec.addConstructor nil
+  let listSort ← tm.mkDatatypeSort dtSpec
+  let d ← listSort.getDatatype
+  let consLen := d.getNumConstructors
+  if h : consLen = 2 then
+    let consConstr := d[0]
+    let nilConstr := d[1]
+    let _consConstrTerm := consConstr.getTerm
+    let _nilConstrTerm := nilConstr.getTerm
+  else
+    println! "unexpected number of constructors: {d.getNumConstructors}"

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1190,11 +1190,147 @@ static inline Solver* solver_unbox(b_lean_obj_arg s)
   return static_cast<Solver*>(lean_get_external_data(s));
 }
 
+static void datatypeConstructorDecl_finalize(void* obj)
+{
+  delete static_cast<DatatypeConstructorDecl*>(obj);
+}
+
+static void datatypeConstructorDecl_foreach(void*, b_lean_obj_arg)
+{
+  // do nothing since `DatatypeConstructorDecl` does not contain nested Lean
+  // objects
+}
+
+static lean_external_class* g_datatypeConstructorDecl_class = nullptr;
+
+static inline lean_obj_res datatypeConstructorDecl_box(
+    DatatypeConstructorDecl* datatypeConstructorDecl)
+{
+  if (g_datatypeConstructorDecl_class == nullptr)
+  {
+    g_datatypeConstructorDecl_class = lean_register_external_class(
+        datatypeConstructorDecl_finalize, datatypeConstructorDecl_foreach);
+  }
+  return lean_alloc_external(g_datatypeConstructorDecl_class,
+                             datatypeConstructorDecl);
+}
+
+static inline const DatatypeConstructorDecl* datatypeConstructorDecl_unbox(
+    b_lean_obj_arg datatypeConstructorDecl)
+{
+  return static_cast<DatatypeConstructorDecl*>(
+      lean_get_external_data(datatypeConstructorDecl));
+}
+
+static inline DatatypeConstructorDecl* mut_datatypeConstructorDecl_unbox(
+    b_lean_obj_arg datatypeConstructorDecl)
+{
+  return static_cast<DatatypeConstructorDecl*>(
+      lean_get_external_data(datatypeConstructorDecl));
+}
+
+static void datatypeDecl_finalize(void* obj)
+{
+  delete static_cast<DatatypeDecl*>(obj);
+}
+
+static void datatypeDecl_foreach(void*, b_lean_obj_arg)
+{
+  // do nothing since `DatatypeDecl` does not contain nested Lean objects
+}
+
+static lean_external_class* g_datatypeDecl_class = nullptr;
+
+static inline lean_obj_res datatypeDecl_box(DatatypeDecl* datatypeDecl)
+{
+  if (g_datatypeDecl_class == nullptr)
+  {
+    g_datatypeDecl_class = lean_register_external_class(datatypeDecl_finalize,
+                                                        datatypeDecl_foreach);
+  }
+  return lean_alloc_external(g_datatypeDecl_class, datatypeDecl);
+}
+
+static inline const DatatypeDecl* datatypeDecl_unbox(
+    b_lean_obj_arg datatypeDecl)
+{
+  return static_cast<DatatypeDecl*>(lean_get_external_data(datatypeDecl));
+}
+
+static inline DatatypeDecl* mut_datatypeDecl_unbox(b_lean_obj_arg datatypeDecl)
+{
+  return static_cast<DatatypeDecl*>(lean_get_external_data(datatypeDecl));
+}
+
+static void datatype_finalize(void* obj) { delete static_cast<Datatype*>(obj); }
+
+static void datatype_foreach(void*, b_lean_obj_arg)
+{
+  // do nothing since `Datatype` does not contain nested Lean objects
+}
+
+static lean_external_class* g_datatype_class = nullptr;
+
+static inline lean_obj_res datatype_box(Datatype* datatype)
+{
+  if (g_datatype_class == nullptr)
+  {
+    g_datatype_class =
+        lean_register_external_class(datatype_finalize, datatype_foreach);
+  }
+  return lean_alloc_external(g_datatype_class, datatype);
+}
+
+static inline const Datatype* datatype_unbox(b_lean_obj_arg datatype)
+{
+  return static_cast<Datatype*>(lean_get_external_data(datatype));
+}
+
+static inline Datatype* mut_datatype_unbox(b_lean_obj_arg datatype)
+{
+  return static_cast<Datatype*>(lean_get_external_data(datatype));
+}
+
+static void datatypeConstructor_finalize(void* obj)
+{
+  delete static_cast<DatatypeConstructor*>(obj);
+}
+
+static void datatypeConstructor_foreach(void*, b_lean_obj_arg)
+{
+  // do nothing since `DatatypeConstructor` does not contain nested Lean objects
+}
+
+static lean_external_class* g_datatypeConstructor_class = nullptr;
+
+static inline lean_obj_res datatypeConstructor_box(
+    DatatypeConstructor* datatype)
+{
+  if (g_datatypeConstructor_class == nullptr)
+  {
+    g_datatypeConstructor_class = lean_register_external_class(
+        datatypeConstructor_finalize, datatypeConstructor_foreach);
+  }
+  return lean_alloc_external(g_datatypeConstructor_class, datatype);
+}
+
+static inline const DatatypeConstructor* datatypeConstructor_unbox(
+    b_lean_obj_arg datatype)
+{
+  return static_cast<DatatypeConstructor*>(lean_get_external_data(datatype));
+}
+
+static inline DatatypeConstructor* mut_datatypeConstructor_unbox(
+    b_lean_obj_arg datatype)
+{
+  return static_cast<DatatypeConstructor*>(lean_get_external_data(datatype));
+}
+
 static void grammar_finalize(void* obj) { delete static_cast<Grammar*>(obj); }
 
 static void grammar_foreach(void*, b_lean_obj_arg)
 {
-  // do nothing since `Command` does not contain nested Lean objects
+  // do nothing since `Grammar` does not contain nested Lean objects
 }
 
 static lean_external_class* g_grammar_class = nullptr;
@@ -1695,6 +1831,326 @@ LEAN_EXPORT lean_obj_res termManager_mkOpOfIndices(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
+LEAN_EXPORT lean_obj_res termManager_mkDatatypeDecl(lean_obj_arg tm,
+                                                    lean_obj_arg name,
+                                                    lean_obj_arg sorts,
+                                                    lean_obj_arg isCoDatatype,
+                                                    lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  std::vector<Sort> ss;
+  for (size_t i = 0, n = lean_array_size(sorts); i < n; ++i)
+  {
+    ss.push_back(*sort_unbox(
+        lean_array_get(sort_box(new Sort()), sorts, lean_usize_to_nat(i))));
+  }
+  return env_val(
+      datatypeDecl_box(new DatatypeDecl(mut_tm_unbox(tm)->mkDatatypeDecl(
+          lean_string_cstr(name), ss, bool_unbox(lean_unbox(isCoDatatype))))),
+      ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res termManager_mkDatatypeConstructorDecl(
+    lean_obj_arg tm, lean_obj_arg name, lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_val(
+      datatypeConstructorDecl_box(new DatatypeConstructorDecl(
+          mut_tm_unbox(tm)->mkDatatypeConstructorDecl(lean_string_cstr(name)))),
+      ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res termManager_mkDatatypeSort(lean_obj_arg tm,
+                                                    lean_obj_arg dtDecl,
+                                                    lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_val(sort_box(new Sort(mut_tm_unbox(tm)->mkDatatypeSort(
+                     *datatypeDecl_unbox(dtDecl)))),
+                 ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+// # DatatypeConstructorDecl imports
+
+LEAN_EXPORT uint8_t datatypeConstructorDecl_isNull(lean_obj_arg dtConsDecl)
+{
+  return bool_box(datatypeConstructorDecl_unbox(dtConsDecl)->isNull());
+}
+
+LEAN_EXPORT lean_obj_res
+datatypeConstructorDecl_toString(lean_obj_arg dtConsDecl)
+{
+  return lean_mk_string(
+      datatypeConstructorDecl_unbox(dtConsDecl)->toString().c_str());
+}
+
+LEAN_EXPORT uint64_t datatypeConstructorDecl_hash(lean_obj_arg dtConsDecl)
+{
+  return std::hash<DatatypeConstructorDecl>()(
+      *datatypeConstructorDecl_unbox(dtConsDecl));
+}
+
+LEAN_EXPORT uint8_t datatypeConstructorDecl_beq(lean_obj_arg l, lean_obj_arg r)
+{
+  return bool_box(*datatypeConstructorDecl_unbox(l)
+                  == *datatypeConstructorDecl_unbox(r));
+}
+
+/** Clones the input datatype constructor declaration if it has strictly more
+than one reference to it, otherwise returns the input datatype constructor
+declaration. */
+lean_obj_arg datatypeConstructorDecl_pseudo_clone(lean_obj_arg dtConsDecl)
+{
+  if (lean_is_exclusive(dtConsDecl))
+    return dtConsDecl;
+  else
+    return datatypeConstructorDecl_box(new DatatypeConstructorDecl(
+        *datatypeConstructorDecl_unbox(dtConsDecl)));
+}
+
+LEAN_EXPORT lean_obj_res
+datatypeConstructorDecl_addSelector(lean_obj_arg dtConsDeclArg,
+                                    lean_obj_arg name,
+                                    lean_obj_arg sort,
+                                    lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg dtConsDecl = datatypeConstructorDecl_pseudo_clone(dtConsDeclArg);
+  mut_datatypeConstructorDecl_unbox(dtConsDecl)
+      ->addSelector(lean_string_cstr(name), *sort_unbox(sort));
+  return env_val(dtConsDecl, ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res datatypeConstructorDecl_addSelectorSelf(
+    lean_obj_arg dtConsDeclArg, lean_obj_arg name, lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg dtConsDecl = datatypeConstructorDecl_pseudo_clone(dtConsDeclArg);
+  mut_datatypeConstructorDecl_unbox(dtConsDecl)
+      ->addSelectorSelf(lean_string_cstr(name));
+  return env_val(dtConsDecl, ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res
+datatypeConstructorDecl_addSelectorUnresolved(lean_obj_arg dtConsDeclArg,
+                                              lean_obj_arg name,
+                                              lean_obj_arg sortName,
+                                              lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg dtConsDecl = datatypeConstructorDecl_pseudo_clone(dtConsDeclArg);
+  mut_datatypeConstructorDecl_unbox(dtConsDecl)
+      ->addSelectorUnresolved(lean_string_cstr(name),
+                              lean_string_cstr(sortName));
+  return env_val(dtConsDecl, ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+// # DatatypeDecl imports
+
+LEAN_EXPORT uint8_t datatypeDecl_isNull(lean_obj_arg dtDecl)
+{
+  return bool_box(datatypeDecl_unbox(dtDecl)->isNull());
+}
+
+LEAN_EXPORT lean_obj_res datatypeDecl_toString(lean_obj_arg dtDecl)
+{
+  return lean_mk_string(datatypeDecl_unbox(dtDecl)->toString().c_str());
+}
+
+LEAN_EXPORT uint64_t datatypeDecl_hash(lean_obj_arg dtDecl)
+{
+  return std::hash<DatatypeDecl>()(*datatypeDecl_unbox(dtDecl));
+}
+
+LEAN_EXPORT uint8_t datatypeDecl_beq(lean_obj_arg l, lean_obj_arg r)
+{
+  return bool_box(*datatypeDecl_unbox(l) == *datatypeDecl_unbox(r));
+}
+
+LEAN_EXPORT uint8_t datatypeDecl_isParametric(lean_obj_arg dtDecl)
+{
+  return bool_box(datatypeDecl_unbox(dtDecl)->isParametric());
+}
+
+LEAN_EXPORT lean_obj_res datatypeDecl_getName(lean_obj_arg dtDecl)
+{
+  return lean_mk_string(datatypeDecl_unbox(dtDecl)->getName().c_str());
+}
+
+/** Clones the input datatype declaration if it has strictly more than one
+reference to it, otherwise returns the input datatype declaration. */
+lean_obj_arg datatypeDecl_pseudo_clone(lean_obj_arg datatypeDecl)
+{
+  if (lean_is_exclusive(datatypeDecl))
+    return datatypeDecl;
+  else
+    return datatypeDecl_box(
+        new DatatypeDecl(*datatypeDecl_unbox(datatypeDecl)));
+}
+
+LEAN_EXPORT lean_obj_res datatypeDecl_addConstructor(lean_obj_arg dtDeclArg,
+                                                     lean_obj_arg dtCons,
+                                                     lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  lean_obj_arg dtDecl = datatypeDecl_pseudo_clone(dtDeclArg);
+  mut_datatypeDecl_unbox(dtDecl)->addConstructor(
+      *datatypeConstructorDecl_unbox(dtCons));
+  return env_val(dtDecl, ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+LEAN_EXPORT lean_obj_res datatypeDecl_getNumConstructors(lean_obj_arg dtDecl)
+{
+  return lean_usize_to_nat(datatypeDecl_unbox(dtDecl)->getNumConstructors());
+}
+
+LEAN_EXPORT lean_obj_res datatypeDecl_isResolved(lean_obj_arg dtDecl,
+                                                 lean_obj_arg ioWorld)
+{
+  CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+  return env_bool(datatypeDecl_unbox(dtDecl)->isResolved(), ioWorld);
+  CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+}
+
+// # Datatype imports
+
+LEAN_EXPORT lean_obj_res sort_getDatatype(lean_obj_arg s)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(datatype_box(new Datatype((sort_unbox(s)->getDatatype()))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
+LEAN_EXPORT lean_obj_res datatype_null(lean_obj_arg unit)
+{
+  return datatype_box(new Datatype());
+}
+
+LEAN_EXPORT uint8_t datatype_isNull(lean_obj_arg datatype)
+{
+  return bool_box(datatype_unbox(datatype)->isNull());
+}
+
+LEAN_EXPORT lean_obj_res datatype_toString(lean_obj_arg datatype)
+{
+  return lean_mk_string(datatype_unbox(datatype)->toString().c_str());
+}
+
+LEAN_EXPORT uint64_t datatype_hash(lean_obj_arg datatype)
+{
+  return std::hash<Datatype>()(*datatype_unbox(datatype));
+}
+
+LEAN_EXPORT uint8_t datatype_beq(lean_obj_arg l, lean_obj_arg r)
+{
+  return bool_box(*datatype_unbox(l) == *datatype_unbox(r));
+}
+
+LEAN_EXPORT uint8_t datatype_isParametric(lean_obj_arg datatype)
+{
+  return bool_box(datatype_unbox(datatype)->isParametric());
+}
+
+LEAN_EXPORT uint8_t datatype_isCodatatype(lean_obj_arg datatype)
+{
+  return bool_box(datatype_unbox(datatype)->isCodatatype());
+}
+
+LEAN_EXPORT lean_obj_res datatype_getName(lean_obj_arg datatype)
+{
+  return lean_mk_string(datatype_unbox(datatype)->getName().c_str());
+}
+
+LEAN_EXPORT lean_obj_res datatype_getNumConstructors(lean_obj_arg datatype)
+{
+  return lean_usize_to_nat(datatype_unbox(datatype)->getNumConstructors());
+}
+
+LEAN_EXPORT lean_obj_res datatype_getConstructor(lean_obj_arg datatype,
+                                                 lean_obj_arg name)
+{
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok(datatypeConstructor_box(new DatatypeConstructor(
+      datatype_unbox(datatype)->getConstructor(lean_string_cstr(name)))));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
+}
+
+LEAN_EXPORT lean_obj_res datatype_getConstructorAt(lean_obj_arg datatype,
+                                                   lean_obj_arg idx)
+{
+  return datatypeConstructor_box(new DatatypeConstructor(
+      (*datatype_unbox(datatype))[lean_usize_of_nat(idx)]));
+}
+
+// /** Clones the input datatype declaration if it has strictly more than one
+// reference to it, otherwise returns the input datatype declaration. */
+// lean_obj_arg datatype_pseudo_clone(lean_obj_arg datatypeDecl)
+// {
+//   if (lean_is_exclusive(datatypeDecl))
+//     return datatypeDecl;
+//   else
+//     return datatype_box(new Datatype(*datatype_unbox(datatypeDecl)));
+// }
+
+// LEAN_EXPORT lean_obj_res datatype_addConstructor(lean_obj_arg datatypeArg,
+//                                                   lean_obj_arg dtCons,
+//                                                   lean_obj_arg ioWorld)
+// {
+//   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+//   lean_obj_arg datatype = datatype_pseudo_clone(datatypeArg);
+//   mut_datatype_unbox(datatype)->addConstructor(*datatypeConstructorDecl_unbox(dtCons));
+//   return env_val(datatype, ioWorld);
+//   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+// }
+
+// LEAN_EXPORT lean_obj_res datatype_isResolved(lean_obj_arg datatype,
+//                                                   lean_obj_arg ioWorld)
+// {
+//   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
+//   return env_bool(datatype_unbox(datatype)->isResolved(), ioWorld);
+//   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
+// }
+
+// # DatatypeConstructor imports
+
+LEAN_EXPORT lean_obj_res datatypeConstructor_null(lean_obj_arg unit)
+{
+  return datatypeConstructor_box(new DatatypeConstructor());
+}
+
+LEAN_EXPORT uint8_t datatypeConstructor_isNull(lean_obj_arg dtCons)
+{
+  return bool_box(datatypeConstructor_unbox(dtCons)->isNull());
+}
+
+LEAN_EXPORT lean_obj_res datatypeConstructor_toString(lean_obj_arg dtCons)
+{
+  return lean_mk_string(datatypeConstructor_unbox(dtCons)->toString().c_str());
+}
+
+LEAN_EXPORT uint64_t datatypeConstructor_hash(lean_obj_arg dtCons)
+{
+  return std::hash<DatatypeConstructor>()(*datatypeConstructor_unbox(dtCons));
+}
+
+LEAN_EXPORT uint8_t datatypeConstructor_beq(lean_obj_arg l, lean_obj_arg r)
+{
+  return bool_box(*datatypeConstructor_unbox(l)
+                  == *datatypeConstructor_unbox(r));
+}
+
+LEAN_EXPORT lean_obj_res datatypeConstructor_getTerm(lean_obj_arg dtCons)
+{
+  return term_box(new Term(datatypeConstructor_unbox(dtCons)->getTerm()));
+}
+
 // # Grammar imports
 
 LEAN_EXPORT uint8_t grammar_isNull(lean_obj_arg gram)
@@ -2055,7 +2511,6 @@ LEAN_EXPORT lean_obj_res solver_getLogic(b_lean_obj_arg solver,
 LEAN_EXPORT lean_obj_res solver_simplify(lean_obj_arg solver,
                                          lean_obj_arg term,
                                          lean_obj_arg applySubs,
-
                                          lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
@@ -2070,7 +2525,6 @@ LEAN_EXPORT lean_obj_res solver_declareFun(lean_obj_arg solver,
                                            lean_obj_arg sorts,
                                            lean_obj_arg sort,
                                            uint8_t fresh,
-
                                            lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -2325,9 +2325,11 @@ LEAN_EXPORT uint8_t datatype_isRecord(lean_obj_arg datatype)
   return bool_box(datatype_unbox(datatype)->isRecord());
 }
 
-LEAN_EXPORT uint8_t datatype_isFinite(lean_obj_arg datatype)
+LEAN_EXPORT lean_obj_res datatype_isFinite(lean_obj_arg datatype)
 {
-  return bool_box(datatype_unbox(datatype)->isFinite());
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
+  return except_ok_bool(bool_box(datatype_unbox(datatype)->isFinite()));
+  CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
 LEAN_EXPORT uint8_t datatype_isWellFounded(lean_obj_arg datatype)

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -1341,8 +1341,7 @@ static void datatypeSelector_foreach(void*, b_lean_obj_arg)
 
 static lean_external_class* g_datatypeSelector_class = nullptr;
 
-static inline lean_obj_res datatypeSelector_box(
-    DatatypeSelector* datatype)
+static inline lean_obj_res datatypeSelector_box(DatatypeSelector* datatype)
 {
   if (g_datatypeSelector_class == nullptr)
   {
@@ -1669,25 +1668,24 @@ LEAN_EXPORT lean_obj_res termManager_mkTupleSort(lean_obj_arg tm,
 }
 
 LEAN_EXPORT lean_obj_res termManager_mkRecordSort(lean_obj_arg tm,
-                                                 lean_obj_arg fields,
-                                                 lean_obj_arg ioWorld)
+                                                  lean_obj_arg fields,
+                                                  lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   std::vector<std::pair<std::string, Sort>> fieldsVec;
   for (size_t i = 0, n = lean_array_size(fields); i < n; ++i)
   {
-    lean_object* prod =
-      lean_array_get(
-        prod_mk(lean_box(0), lean_box(0), lean_mk_string(""), sort_box(new Sort())),
+    lean_object* prod = lean_array_get(
+        prod_mk(
+            lean_box(0), lean_box(0), lean_mk_string(""), sort_box(new Sort())),
         fields,
-        lean_usize_to_nat(i)
-      );
+        lean_usize_to_nat(i));
     fieldsVec.push_back(std::make_pair(
-      lean_string_cstr(prod_fst(lean_box(0), lean_box(0), prod)),
-      *sort_unbox(prod_snd(lean_box(0), lean_box(0), prod))
-    ));
+        lean_string_cstr(prod_fst(lean_box(0), lean_box(0), prod)),
+        *sort_unbox(prod_snd(lean_box(0), lean_box(0), prod))));
   }
-  return env_val(sort_box(new Sort(mut_tm_unbox(tm)->mkRecordSort(fieldsVec))), ioWorld);
+  return env_val(sort_box(new Sort(mut_tm_unbox(tm)->mkRecordSort(fieldsVec))),
+                 ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
@@ -1746,10 +1744,11 @@ LEAN_EXPORT lean_obj_res termManager_mkUninterpretedSort(lean_obj_arg tm,
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res termManager_mkUnresolvedDatatypeSort(lean_obj_arg tm,
-                                                         lean_obj_arg symbol,
-                                                         lean_obj_arg arity,
-                                                         lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res
+termManager_mkUnresolvedDatatypeSort(lean_obj_arg tm,
+                                     lean_obj_arg symbol,
+                                     lean_obj_arg arity,
+                                     lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   return env_val(sort_box(new Sort(mut_tm_unbox(tm)->mkUnresolvedDatatypeSort(
@@ -1947,15 +1946,15 @@ LEAN_EXPORT lean_obj_res termManager_mkDatatypeSort(lean_obj_arg tm,
 }
 
 LEAN_EXPORT lean_obj_res termManager_mkDatatypeSorts(lean_obj_arg tm,
-                                                    lean_obj_arg dtDecls,
-                                                    lean_obj_arg ioWorld)
+                                                     lean_obj_arg dtDecls,
+                                                     lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   std::vector<DatatypeDecl> dtDeclsVec;
   for (size_t i = 0, n = lean_array_size(dtDecls); i < n; ++i)
   {
-    dtDeclsVec.push_back(*datatypeDecl_unbox(
-        lean_array_get(datatypeDecl_box(new DatatypeDecl()), dtDecls, lean_usize_to_nat(i))));
+    dtDeclsVec.push_back(*datatypeDecl_unbox(lean_array_get(
+        datatypeDecl_box(new DatatypeDecl()), dtDecls, lean_usize_to_nat(i))));
   }
   std::vector<Sort> sortsVec = mut_tm_unbox(tm)->mkDatatypeSorts(dtDeclsVec);
   lean_object* sorts = lean_mk_empty_array();
@@ -2093,7 +2092,8 @@ LEAN_EXPORT lean_obj_res datatypeDecl_isResolved(lean_obj_arg dtDecl,
 LEAN_EXPORT lean_obj_res datatypeDecl_getName(lean_obj_arg dtDecl)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok(lean_mk_string(datatypeDecl_unbox(dtDecl)->getName().c_str()));
+  return except_ok(
+      lean_mk_string(datatypeDecl_unbox(dtDecl)->getName().c_str()));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
@@ -2149,35 +2149,43 @@ LEAN_EXPORT uint64_t datatypeSelector_hash(lean_obj_arg dtCons)
 
 LEAN_EXPORT uint8_t datatypeSelector_beq(lean_obj_arg l, lean_obj_arg r)
 {
-  return bool_box(*datatypeSelector_unbox(l)
-                  == *datatypeSelector_unbox(r));
+  return bool_box(*datatypeSelector_unbox(l) == *datatypeSelector_unbox(r));
 }
 
 LEAN_EXPORT lean_obj_res datatypeSelector_getName(lean_obj_arg dtSelector)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok(lean_mk_string(datatypeSelector_unbox(dtSelector)->getName().c_str()));
+  return except_ok(
+      lean_mk_string(datatypeSelector_unbox(dtSelector)->getName().c_str()));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
-LEAN_EXPORT lean_obj_res datatypeSelector_getTerm(lean_obj_arg dtCons, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeSelector_getTerm(lean_obj_arg dtCons,
+                                                  lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(term_box(new Term(datatypeSelector_unbox(dtCons)->getTerm())), ioWorld);
+  return env_val(term_box(new Term(datatypeSelector_unbox(dtCons)->getTerm())),
+                 ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res datatypeSelector_getUpdaterTerm(lean_obj_arg dtCons, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeSelector_getUpdaterTerm(lean_obj_arg dtCons,
+                                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(term_box(new Term(datatypeSelector_unbox(dtCons)->getUpdaterTerm())), ioWorld);
+  return env_val(
+      term_box(new Term(datatypeSelector_unbox(dtCons)->getUpdaterTerm())),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res datatypeSelector_getCodomainSort(lean_obj_arg dtCons, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeSelector_getCodomainSort(lean_obj_arg dtCons,
+                                                          lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(sort_box(new Sort(datatypeSelector_unbox(dtCons)->getCodomainSort())), ioWorld);
+  return env_val(
+      sort_box(new Sort(datatypeSelector_unbox(dtCons)->getCodomainSort())),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
@@ -2205,53 +2213,70 @@ LEAN_EXPORT uint64_t datatypeConstructor_hash(lean_obj_arg dtCons)
 
 LEAN_EXPORT uint8_t datatypeConstructor_beq(lean_obj_arg l, lean_obj_arg r)
 {
-  return bool_box(*datatypeConstructor_unbox(l) == *datatypeConstructor_unbox(r));
+  return bool_box(*datatypeConstructor_unbox(l)
+                  == *datatypeConstructor_unbox(r));
 }
 
 LEAN_EXPORT lean_obj_res datatypeConstructor_getName(lean_obj_arg dtConstructor)
 {
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_BEGIN;
-  return except_ok(lean_mk_string(datatypeConstructor_unbox(dtConstructor)->getName().c_str()));
+  return except_ok(lean_mk_string(
+      datatypeConstructor_unbox(dtConstructor)->getName().c_str()));
   CVC5_LEAN_API_TRY_CATCH_EXCEPT_END;
 }
 
-LEAN_EXPORT lean_obj_res datatypeConstructor_getTerm(lean_obj_arg dtCons, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeConstructor_getTerm(lean_obj_arg dtCons,
+                                                     lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(term_box(new Term(datatypeConstructor_unbox(dtCons)->getTerm())), ioWorld);
+  return env_val(
+      term_box(new Term(datatypeConstructor_unbox(dtCons)->getTerm())),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res datatypeConstructor_getInstantiatedTerm(lean_obj_arg dtCons, lean_obj_arg retSort, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeConstructor_getInstantiatedTerm(
+    lean_obj_arg dtCons, lean_obj_arg retSort, lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(term_box(new Term(datatypeConstructor_unbox(dtCons)->getInstantiatedTerm(*sort_unbox(retSort)))), ioWorld);
+  return env_val(
+      term_box(new Term(datatypeConstructor_unbox(dtCons)->getInstantiatedTerm(
+          *sort_unbox(retSort)))),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res datatypeConstructor_getTesterTerm(lean_obj_arg dtCons, lean_obj_arg ioWorld)
+LEAN_EXPORT lean_obj_res datatypeConstructor_getTesterTerm(lean_obj_arg dtCons,
+                                                           lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(term_box(new Term(datatypeConstructor_unbox(dtCons)->getTesterTerm())), ioWorld);
+  return env_val(
+      term_box(new Term(datatypeConstructor_unbox(dtCons)->getTesterTerm())),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
-LEAN_EXPORT lean_obj_res datatypeConstructor_getNumSelectors(lean_obj_arg dtCons)
+LEAN_EXPORT lean_obj_res
+datatypeConstructor_getNumSelectors(lean_obj_arg dtCons)
 {
-  return lean_usize_to_nat(datatypeConstructor_unbox(dtCons)->getNumSelectors());
+  return lean_usize_to_nat(
+      datatypeConstructor_unbox(dtCons)->getNumSelectors());
 }
 
 LEAN_EXPORT lean_obj_res datatypeConstructor_getSelector(lean_obj_arg dtCons,
-                                                 lean_obj_arg name, lean_obj_arg ioWorld)
+                                                         lean_obj_arg name,
+                                                         lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
   return env_val(datatypeSelector_box(new DatatypeSelector(
-      datatypeConstructor_unbox(dtCons)->getSelector(lean_string_cstr(name)))), ioWorld);
+                     datatypeConstructor_unbox(dtCons)->getSelector(
+                         lean_string_cstr(name)))),
+                 ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
 LEAN_EXPORT lean_obj_res datatypeConstructor_getSelectorAt(lean_obj_arg dtCons,
-                                                   lean_obj_arg idx)
+                                                           lean_obj_arg idx)
 {
   return datatypeSelector_box(new DatatypeSelector(
       (*datatypeConstructor_unbox(dtCons))[lean_usize_of_nat(idx)]));
@@ -2351,11 +2376,13 @@ LEAN_EXPORT lean_obj_res datatype_getNumConstructors(lean_obj_arg datatype)
 
 LEAN_EXPORT lean_obj_res datatype_getConstructor(lean_obj_arg datatype,
                                                  lean_obj_arg name,
-                                                lean_obj_arg ioWorld)
+                                                 lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(datatypeConstructor_box(new DatatypeConstructor(
-      datatype_unbox(datatype)->getConstructor(lean_string_cstr(name)))), ioWorld);
+  return env_val(
+      datatypeConstructor_box(new DatatypeConstructor(
+          datatype_unbox(datatype)->getConstructor(lean_string_cstr(name)))),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
@@ -2363,17 +2390,18 @@ LEAN_EXPORT lean_obj_res datatype_getConstructorAt(lean_obj_arg datatype,
                                                    lean_obj_arg idx)
 {
   return datatypeConstructor_box(new DatatypeConstructor(
-      (*datatype_unbox(datatype))[lean_usize_of_nat(idx)]
-  ));
+      (*datatype_unbox(datatype))[lean_usize_of_nat(idx)]));
 }
 
 LEAN_EXPORT lean_obj_res datatype_getSelector(lean_obj_arg datatype,
-                                                 lean_obj_arg name,
-                                                lean_obj_arg ioWorld)
+                                              lean_obj_arg name,
+                                              lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  return env_val(datatypeSelector_box(new DatatypeSelector(
-      datatype_unbox(datatype)->getSelector(lean_string_cstr(name)))), ioWorld);
+  return env_val(
+      datatypeSelector_box(new DatatypeSelector(
+          datatype_unbox(datatype)->getSelector(lean_string_cstr(name)))),
+      ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }
 
@@ -2740,8 +2768,8 @@ LEAN_EXPORT lean_obj_res solver_simplify(lean_obj_arg solver,
                                          lean_obj_arg ioWorld)
 {
   CVC5_LEAN_API_TRY_CATCH_ENV_BEGIN;
-  Term value = solver_unbox(solver)->simplify(
-      *term_unbox(term), bool_unbox(applySubs));
+  Term value =
+      solver_unbox(solver)->simplify(*term_unbox(term), bool_unbox(applySubs));
   return env_val(term_box(new Term(value)), ioWorld);
   CVC5_LEAN_API_TRY_CATCH_ENV_END(ioWorld);
 }


### PR DESCRIPTION
- lift the *datatype* API:
  - types `DatatypeConstructorDecl`, `DatatypeDecl`, `DatatypeSelector`, `DatatypeConstructor`, and `Datatype`;
  - all functions associated to these types
- add [the *datatype*-related unit tests from the cvc5 repository](https://github.com/cvc5/cvc5/blob/main/test/unit/api/cpp/api_datatype_black.cpp)

**NB:** all types ending in `Decl` are builders that, at C++ level, are modified by side-effects until the final non-`Decl` values are created, which are read-only. To properly reflect this at lean-level without compromising soundness, this PR follows the approach used in #29 for grammars, inspired by lean's handling of arrays: mutations over `Decl`-types use pseudo-cloning, meaning (references to) values of these types are cloned if the reference count is strictly greater than one, and the functions return the mutated clone; otherwise the uniquely-referenced (*i.e.* "owned") value is mutated and returned.