### PR TITLE
fix: memory-safety bug in `TermManager.mkRecordSort`

### DIFF
--- a/cvc5.lean
+++ b/cvc5.lean
@@ -14,12 +14,6 @@ import cvc5.Types
 @[export prod_mk]
 private def mkProd := @Prod.mk
 
-@[export prod_fst]
-private def prodFst := @Prod.fst
-
-@[export prod_snd]
-private def prodSnd := @Prod.snd
-
 namespace cvc5
 
 namespace Kind

--- a/cvc5Test/Regression/Issue33.lean
+++ b/cvc5Test/Regression/Issue33.lean
@@ -1,0 +1,19 @@
+/-
+Copyright (c) 2023-2024 by the authors listed in the file AUTHORS and their
+institutional affiliations. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Abdalrhman Mohamed, Adrien Champion
+-/
+
+import cvc5Test.Init
+
+/-!
+https://github.com/abdoo8080/lean-cvc5/issues/33
+-/
+
+namespace cvc5.Test
+
+test![Issue33, mkRecordSort] tm => do
+  let fields := #[ ("field1", ← tm.getIntegerSort), ("field2", ← tm.getBooleanSort) ]
+  tm.mkRecordSort fields |> assertOkDiscard
+  tm.mkRecordSort fields |> assertOkDiscard

--- a/cvc5Test/Unit/ApiSort.lean
+++ b/cvc5Test/Unit/ApiSort.lean
@@ -181,10 +181,10 @@ test![TestApiBlackSort, isNullable] tm => do
   let n := cvc5.Sort.null ()
   assertFalse n.isNullable
 
--- test![TestApiBlackSort, isRecord] tm => do
---   assertEq (← mkRecordSort #[("asdf", ← getRealSort)]).isRecord true
---   let n := cvc5.Sort.null ()
---   assertFalse n.isRecord
+test![TestApiBlackSort, isRecord] tm => do
+  assertEq (← tm.mkRecordSort #[("asdf", ← tm.getRealSort)]).isRecord true
+  let n := cvc5.Sort.null ()
+  assertFalse n.isRecord
 
 test![TestApiBlackSort, isArray] tm => do
   assertTrue (← tm.mkArraySort (← tm.getRealSort) (← tm.getIntegerSort)).isArray

--- a/ffi/ffi.cpp
+++ b/ffi/ffi.cpp
@@ -11,8 +11,17 @@ lean_obj_res prod_mk(lean_obj_arg T,
                      lean_obj_arg t,
                      lean_obj_arg u);
 
-lean_obj_res prod_fst(lean_obj_arg T, lean_obj_arg U, lean_obj_arg pair);
-lean_obj_res prod_snd(lean_obj_arg T, lean_obj_arg U, lean_obj_arg pair);
+/** Borrows the first element of a product/pair, does not change any ref-count. */
+lean_obj_res prod_fst(b_lean_obj_arg prod) {
+  lean_obj_res res = lean_ctor_get(prod, 0);
+  return res;
+}
+
+/** Borrows the second element of a product/pair, does not change any ref-count. */
+lean_obj_res prod_snd(b_lean_obj_arg prod) {
+  lean_obj_res res = lean_ctor_get(prod, 1);
+  return res;
+}
 
 // # `Except Error α` constructors
 
@@ -1681,8 +1690,8 @@ LEAN_EXPORT lean_obj_res termManager_mkRecordSort(lean_obj_arg tm,
         fields,
         lean_usize_to_nat(i));
     fieldsVec.push_back(std::make_pair(
-        lean_string_cstr(prod_fst(lean_box(0), lean_box(0), prod)),
-        *sort_unbox(prod_snd(lean_box(0), lean_box(0), prod))));
+        lean_string_cstr(prod_fst(prod)),
+        *sort_unbox(prod_snd(prod))));
   }
   return env_val(sort_box(new Sort(mut_tm_unbox(tm)->mkRecordSort(fieldsVec))),
                  ioWorld);


### PR DESCRIPTION
fixes #33 