### PR TITLE
chore: turn all lean files into modules

### DIFF
--- a/PreBuild.lean
+++ b/PreBuild.lean
@@ -1,3 +1,5 @@
+module
+
 import Lean.Data.Position
 import Std.Internal.Parsec
 
@@ -71,7 +73,7 @@ def Enum.writeToLean (e : Enum) (skipIfDefs := true) : IO Unit := do
   -- write the type's doc
   e.doc.writeToLean h pref
   -- type definition
-  wln ["inductive ", e.ident, " where"]
+  wln ["public inductive ", e.ident, " where"]
   -- write each variant (and its doc), populate `listAll`'s definition
   for v in e.variants do
     -- ignore variants inside `#ifdef`?
@@ -108,6 +110,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/\
   "]
+  wln []
+  wln ["module"]
   wln []
   wln ["namespace cvc5"]
   for e in es do
@@ -555,7 +559,7 @@ def fail (s : String) : IO α :=
   throw (.userError s)
 
 open cvc5.PreBuild.Fs in
-def main (args : List String) : IO Unit := do
+public def main (args : List String) : IO Unit := do
   let (cppDir, leanDir) ← match args with
     | [cpp, lean] => pure ((cpp, lean) : FilePath × FilePath)
     | l => fail s!"expected exactly 2 arguments, found {l.length}"

--- a/PreBuild.lean
+++ b/PreBuild.lean
@@ -73,7 +73,7 @@ def Enum.writeToLean (e : Enum) (skipIfDefs := true) : IO Unit := do
   -- write the type's doc
   e.doc.writeToLean h pref
   -- type definition
-  wln ["public inductive ", e.ident, " where"]
+  wln ["inductive ", e.ident, " where"]
   -- write each variant (and its doc), populate `listAll`'s definition
   for v in e.variants do
     -- ignore variants inside `#ifdef`?
@@ -112,6 +112,7 @@ Authors: Abdalrhman Mohamed, Adrien Champion
   "]
   wln []
   wln ["module"]
+  wln ["public section"]
   wln []
   wln ["namespace cvc5"]
   for e in es do

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -5,11 +5,16 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
-import cvc5.Init
-import cvc5.Kind
-import cvc5.ProofRule
-import cvc5.SkolemId
-import cvc5.Types
+module
+
+meta import cvc5.Init
+
+public import cvc5.Kind
+public import cvc5.ProofRule
+public import cvc5.SkolemId
+public import cvc5.Types
+
+public section
 
 @[export prod_mk_generic]
 private def mkProd := @Prod.mk

--- a/cvc5.lean
+++ b/cvc5.lean
@@ -3651,3 +3651,5 @@ extern_def findSynthNext : Solver → Env Term
 end Solver
 
 end cvc5
+
+end

--- a/cvc5/Init.lean
+++ b/cvc5/Init.lean
@@ -5,7 +5,9 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
-import Lean.Elab.Command
+module
+
+public meta import Lean.Elab.Command
 
 namespace cvc5
 
@@ -31,7 +33,7 @@ Stolen from [batteries].
 
 [batteries]: https://leanprover-community.github.io/mathlib4_docs/Batteries/Lean/Expr.html#Lean.Expr.forallArity
 -/
-def forallArity : Expr → Nat
+meta def forallArity : Expr → Nat
   | .mdata _ b => forallArity b
   | .forallE _ _ body _ => 1 + forallArity body
   | _ => 0
@@ -290,7 +292,7 @@ scoped syntax (name := multidefs)
 : command
 
 @[inherit_doc multidefs, command_elab multidefs]
-unsafe def multidefsImpl : CommandElab
+public meta unsafe def multidefsImpl : CommandElab
 | `(command|
   external! $[in $pref:str]? $[$defsItems]*
 ) => do
@@ -354,7 +356,7 @@ scoped syntax (name := externdef)
 : command
 
 @[inherit_doc externdef, command_elab externdef]
-unsafe def externdefImpl : CommandElab
+public meta unsafe def externdefImpl : CommandElab
 | `(command|
   $mods:declModifiers
   $externKw $[in $path:str]? $ident $sig $[$tail]?

--- a/cvc5/Kind.lean
+++ b/cvc5/Kind.lean
@@ -6,6 +6,7 @@ Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
 module
+public section
 
 namespace cvc5
 
@@ -22,7 +23,7 @@ export to its corresponding internal kinds. The underlying type of
 of this type depends on the size of `cvc5::internal::Kind`
 (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h).
 -/
-public inductive Kind where
+inductive Kind where
   /--
   Internal kind.
   
@@ -6017,7 +6018,7 @@ export to its corresponding internal kinds. The underlying type of
 of this type depends on the size of `cvc5::internal::Kind`
 (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h).
 -/
-public inductive SortKind where
+inductive SortKind where
   /--
   Internal kind.
   

--- a/cvc5/Kind.lean
+++ b/cvc5/Kind.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
+module
+
 namespace cvc5
 
 /--
@@ -20,7 +22,7 @@ export to its corresponding internal kinds. The underlying type of
 of this type depends on the size of `cvc5::internal::Kind`
 (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h).
 -/
-inductive Kind where
+public inductive Kind where
   /--
   Internal kind.
   
@@ -6015,7 +6017,7 @@ export to its corresponding internal kinds. The underlying type of
 of this type depends on the size of `cvc5::internal::Kind`
 (`NodeValue::NBITS_KIND`, currently 10 bits, see expr/node_value.h).
 -/
-inductive SortKind where
+public inductive SortKind where
   /--
   Internal kind.
   

--- a/cvc5/ProofRule.lean
+++ b/cvc5/ProofRule.lean
@@ -6,6 +6,7 @@ Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
 module
+public section
 
 namespace cvc5
 
@@ -58,7 +59,7 @@ rules. These exist for convenience and can be replaced by their definition
 in post-processing.
 \endverbatim
 -/
-public inductive ProofRule where
+inductive ProofRule where
   /--
   \verbatim embed:rst:leading-asterisk
   **Assumption (a leaf)**
@@ -2481,7 +2482,7 @@ and the :cpp:enumerator:`THEORY_REWRITE <cvc5::ProofRule::THEORY_REWRITE>`
 proof rule.
 \endverbatim
 -/
-public inductive ProofRewriteRule where
+inductive ProofRewriteRule where
   | NONE
   /--
   \verbatim embed:rst:leading-asterisk

--- a/cvc5/ProofRule.lean
+++ b/cvc5/ProofRule.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
+module
+
 namespace cvc5
 
 /--
@@ -56,7 +58,7 @@ rules. These exist for convenience and can be replaced by their definition
 in post-processing.
 \endverbatim
 -/
-inductive ProofRule where
+public inductive ProofRule where
   /--
   \verbatim embed:rst:leading-asterisk
   **Assumption (a leaf)**
@@ -2479,7 +2481,7 @@ and the :cpp:enumerator:`THEORY_REWRITE <cvc5::ProofRule::THEORY_REWRITE>`
 proof rule.
 \endverbatim
 -/
-inductive ProofRewriteRule where
+public inductive ProofRewriteRule where
   | NONE
   /--
   \verbatim embed:rst:leading-asterisk

--- a/cvc5/SkolemId.lean
+++ b/cvc5/SkolemId.lean
@@ -5,6 +5,8 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
+module
+
 namespace cvc5
 
 /--
@@ -39,7 +41,7 @@ are empty and the skolem has a functional type ``(-> Real Real)``.
 \internal
 
 -/
-inductive SkolemId where
+public inductive SkolemId where
   /--
   The identifier of the skolem is not exported. These skolems should not
   appear in any user-level API calls.

--- a/cvc5/SkolemId.lean
+++ b/cvc5/SkolemId.lean
@@ -6,6 +6,7 @@ Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
 module
+public section
 
 namespace cvc5
 
@@ -41,7 +42,7 @@ are empty and the skolem has a functional type ``(-> Real Real)``.
 \internal
 
 -/
-public inductive SkolemId where
+inductive SkolemId where
   /--
   The identifier of the skolem is not exported. These skolems should not
   appear in any user-level API calls.

--- a/cvc5/Types.lean
+++ b/cvc5/Types.lean
@@ -6,13 +6,14 @@ Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
 module
+public section
 
 namespace cvc5
 
 /--
 The different reasons for returning an "unknown" result.
 -/
-public inductive UnknownExplanation where
+inductive UnknownExplanation where
   /--
   Full satisfiability check required (e.g., if only preprocessing was
   performed).
@@ -70,7 +71,7 @@ The rounding modes are specified in Sections 4.3.1 and 4.3.2 of the IEEE
 Standard 754.
 \endverbatim
 -/
-public inductive RoundingMode where
+inductive RoundingMode where
   /--
   Round to the nearest even number.
   
@@ -116,7 +117,7 @@ Mode for blocking models.
 Specifies how models are blocked in Solver::blockModel and
 Solver::blockModelValues.
 -/
-public inductive BlockModelsMode where
+inductive BlockModelsMode where
   /--
   Block models based on the SAT skeleton. 
   -/
@@ -136,7 +137,7 @@ Solver::getLearnedLiterals.
 Note that a literal may conceptually belong to multiple categories. We
 classify literals based on the first criteria in this list that they meet.
 -/
-public inductive LearnedLitType where
+inductive LearnedLitType where
   /--
   An equality that was turned into a substitution during preprocessing.
   
@@ -189,7 +190,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 Components to include in a proof.
 -/
-public inductive ProofComponent where
+inductive ProofComponent where
   /--
   Proofs of G1 ... Gn whose free assumptions are a subset of
   F1, ... Fm, where:
@@ -245,7 +246,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 Proof format used for proof printing.
 -/
-public inductive ProofFormat where
+inductive ProofFormat where
   /--
   Do not translate proof output. 
   -/
@@ -276,7 +277,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 Find synthesis targets, used as an argument to Solver::findSynth. These
 specify various kinds of terms that can be found by this method.
 -/
-public inductive FindSynthTarget where
+inductive FindSynthTarget where
   /--
   Find the next term in the enumeration of the target grammar.
   -/
@@ -326,7 +327,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 Option category enumeration.
 Specifies the category of an option for user interface purposes.
 -/
-public inductive OptionCategory where
+inductive OptionCategory where
   /--
   Option available to regular users 
   -/
@@ -348,7 +349,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 The different reasons for returning an "unknown" result.
 -/
-public inductive InputLanguage where
+inductive InputLanguage where
   /--
   The SMT-LIB version 2.6 language 
   -/

--- a/cvc5/Types.lean
+++ b/cvc5/Types.lean
@@ -5,12 +5,14 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Abdalrhman Mohamed, Adrien Champion
 -/
 
+module
+
 namespace cvc5
 
 /--
 The different reasons for returning an "unknown" result.
 -/
-inductive UnknownExplanation where
+public inductive UnknownExplanation where
   /--
   Full satisfiability check required (e.g., if only preprocessing was
   performed).
@@ -68,7 +70,7 @@ The rounding modes are specified in Sections 4.3.1 and 4.3.2 of the IEEE
 Standard 754.
 \endverbatim
 -/
-inductive RoundingMode where
+public inductive RoundingMode where
   /--
   Round to the nearest even number.
   
@@ -114,7 +116,7 @@ Mode for blocking models.
 Specifies how models are blocked in Solver::blockModel and
 Solver::blockModelValues.
 -/
-inductive BlockModelsMode where
+public inductive BlockModelsMode where
   /--
   Block models based on the SAT skeleton. 
   -/
@@ -134,7 +136,7 @@ Solver::getLearnedLiterals.
 Note that a literal may conceptually belong to multiple categories. We
 classify literals based on the first criteria in this list that they meet.
 -/
-inductive LearnedLitType where
+public inductive LearnedLitType where
   /--
   An equality that was turned into a substitution during preprocessing.
   
@@ -187,7 +189,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 Components to include in a proof.
 -/
-inductive ProofComponent where
+public inductive ProofComponent where
   /--
   Proofs of G1 ... Gn whose free assumptions are a subset of
   F1, ... Fm, where:
@@ -243,7 +245,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 Proof format used for proof printing.
 -/
-inductive ProofFormat where
+public inductive ProofFormat where
   /--
   Do not translate proof output. 
   -/
@@ -274,7 +276,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 Find synthesis targets, used as an argument to Solver::findSynth. These
 specify various kinds of terms that can be found by this method.
 -/
-inductive FindSynthTarget where
+public inductive FindSynthTarget where
   /--
   Find the next term in the enumeration of the target grammar.
   -/
@@ -324,7 +326,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 Option category enumeration.
 Specifies the category of an option for user interface purposes.
 -/
-inductive OptionCategory where
+public inductive OptionCategory where
   /--
   Option available to regular users 
   -/
@@ -346,7 +348,7 @@ deriving Inhabited, Repr, BEq, DecidableEq
 /--
 The different reasons for returning an "unknown" result.
 -/
-inductive InputLanguage where
+public inductive InputLanguage where
   /--
   The SMT-LIB version 2.6 language 
   -/


### PR DESCRIPTION
Switch to [`module`s](https://lean-lang.org/doc/reference/latest/Source-Files-and-Modules/#module-scopes). Since modules cannot import non-module files, this allows users to import lean-cvc5 from a module-file.